### PR TITLE
select will either return an empty string or an array that contains e…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Access key and secret key should be optional
 - Added 3XX metric collection to the ELB metrics plugins
 - Fixed the metric type for SurgeQueueLength ELB metrics
+- Fixed logic for ec2 instance event inclusion
 
 ## [0.0.2] - 2015-06-02
 ### Fixed

--- a/bin/check-instance-events.rb
+++ b/bin/check-instance-events.rb
@@ -93,7 +93,8 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
           #         "not_after": "2015-01-05 18:00:00 UTC"
           #     }
           # ]
-          unless i[:events_set].select { |x| x[:code] == 'system-reboot' && x[:description] =~ /\[Completed\]/ }
+          useful_events = i[:events_set].reject { |x| x[:code] == 'system-reboot' && x[:description] =~ /\[Completed\]/ }
+          unless useful_events.empty?
             event_instances << i[:instance_id]
           end
         end


### PR DESCRIPTION
…lements that match.  We actually want to check to see if other elements exist that don't match system-reboot