### PR TITLE
handler-ec2_node checks for an empty instances array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - Added check-ec2-filter to compare filter results to given thresholds
 
+### Fixed
+- handler-ec2_node accounts for an empty instances array
+
 ## [1.1.0] - 2015-07-24
 ### Added
 - Added new AWS SES handler - handler-ses.rb

--- a/bin/handler-ec2_node.rb
+++ b/bin/handler-ec2_node.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 #
 # CHANGELOG:
+# * 0.6.0:
+#   - Fixed ec2_node_should_be_deleted to account for an empty insances array
 # * 0.5.0:
 #   - Adds configuration to filter by state reason
 # * 0.4.0:
@@ -130,7 +132,7 @@ class Ec2Node < Sensu::Handler
     states = @event['client']['ec2_states'] || settings['ec2_node']['ec2_states'] || ['shutting-down', 'terminated', 'stopping', 'stopped']
     begin
       instances = ec2.describe_instances(instance_ids: [@event['client']['name']]).reservations[0]
-      if instances.nil?
+      if instances.nil? || instances.empty?
         true
       else
         instance = instances.instances[0]


### PR DESCRIPTION
The current handler will fail if the instances array is empty due to instance being a Nil object.