### PR TITLE
Checking for state reason being nil before looking getting code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
+## Unreleased
+### Fixed
+- handler-ec2_node checks for state_reason being nil prior to code access
+
 ## [1.2.0] - 2015-08-04
 ### Added
 - Added check-ec2-filter to compare filter results to given thresholds

--- a/bin/handler-ec2_node.rb
+++ b/bin/handler-ec2_node.rb
@@ -136,7 +136,7 @@ class Ec2Node < Sensu::Handler
         true
       else
         instance = instances.instances[0]
-        state_reason = instance.state_reason.code
+        state_reason = instance.state_reason.nil? ? nil : instance.state_reason.code
         state = instance.state.name
         states.include?(state) && state_reasons.any? { |reason| Regexp.new(reason) =~ state_reason }
       end


### PR DESCRIPTION
EC2 can return an instance in a Running state. In this case the state_reason will be nil so that accessing the code will result in an exception.