### PR TITLE
Remove puts from block and return correct value

### DIFF
--- a/bin/check-elb-sum-requests.rb
+++ b/bin/check-elb-sum-requests.rb
@@ -126,14 +126,14 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
   def check_sum_requests(elb)
     metric        = latency_metric elb.name
     metric_value  = begin
-                      value = latest_value metric
-                      puts value
+                      latest_value metric
                     rescue
                       0
                     end
 
     @severities.keys.each do |severity|
       threshold = config[:"#{severity}_over"]
+      puts metric_value
       next unless threshold
       next if metric_value < threshold
       flag_alert severity,


### PR DESCRIPTION
This PR ensures that the correct value is returned from the block and changes the `puts` statement to a different location. 

Before:
```
sheela@hostname:~/sensu/sensu-plugins-aws/bin$ ./check-elb-sum-requests.rb --critical-over 1
37.0
Check failed to run: undefined method `<' for nil:NilClass, ["./check-elb-sum-requests.rb:138:in `block in check_sum_requests'", "./check-elb-sum-requests.rb:135:in `each'", "./check-elb-sum-requests.rb:135:in `check_sum_requests'", "./check-elb-sum-requests.rb:157:in `block in run'", "./check-elb-sum-requests.rb:157:in `each'", "./check-elb-sum-requests.rb:157:in `run'", "/var/lib/gems/1.9.1/gems/sensu-plugin-1.1.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

The block on line 128 will always return nil because of the puts statement. As a result, the comparison [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/bin/check-elb-sum-requests.rb#L138) will fail. 

After the change - 

```
sheela@hostname:~/sensu/sensu-plugins-aws$ ./bin/check-elb-sum-requests.rb  --critical-over 1
27.0
CheckELBSumRequests CRITICAL: 24 load balancers total; <AWS::ELB::LoadBalancer name:redacted>'s Sum Requests is 27.0. (expected lower than 1.0); ( within 60 seconds between 2015-08-27 21:07:49 +0000 to 2015-08-27 21:08:49 +0000)

```