### PR TITLE
Gather node metrics from Elasticache if relevant

### DIFF
--- a/bin/metrics-elasticache.rb
+++ b/bin/metrics-elasticache.rb
@@ -98,6 +98,21 @@ class ElastiCacheMetrics < Sensu::Plugin::Metric::CLI::Graphite
                      config[:scheme]
                    end
 
+    dimensions = if config[:cachenodeid]
+                   [{
+                     'name' => 'CacheClusterId',
+                     'value' => config[:cacheclusterid]
+                   }, {
+                     'name' => 'CacheNodeId',
+                     'value' => config[:cachenodeid]
+                   }]
+                 else
+                   [{
+                     'name' => 'CacheClusterId',
+                     'value' => config[:cacheclusterid]
+                   }]
+                 end
+
     statistic_type = {
       'redis' => {
         'CPUUtilization' => 'Percent',
@@ -168,9 +183,7 @@ class ElastiCacheMetrics < Sensu::Plugin::Metric::CLI::Graphite
       options = {
         'namespace' => 'AWS/ElastiCache',
         'metric_name' => config[:metric],
-        'dimensions' => [
-          { 'name' => 'CacheClusterId', 'value' => config[:cacheclusterid] }
-        ],
+        'dimensions' => dimensions,
         'start_time' => st.iso8601,
         'end_time' => et.iso8601,
         'period' => 60,


### PR DESCRIPTION
Before that per cluster metrics were always gathered even if a node was
specified. This is a wrong behaviour as when I specify a node I
expect node wide metrics, not cluster wide.