### PR TITLE
Adding RDS event message as output on check-rds-events.rb

### DIFF
--- a/bin/check-rds-events.rb
+++ b/bin/check-rds-events.rb
@@ -64,7 +64,7 @@ class CheckRDSEvents < Sensu::Plugin::Check::CLI
     if clusters.empty?
       ok
     else
-      critical("Clusters w/ critical events: #{clusters.join(',')}")
+      critical("Clusters w/ critical events: #{clusters.join(', ')}")
     end
   end
 
@@ -82,7 +82,8 @@ class CheckRDSEvents < Sensu::Plugin::Check::CLI
         next if events_record[:events].empty?
 
         # if the last event is a start maint event then the cluster is still in maint
-        maint_clusters.push(cluster_name) if events_record[:events][-1][:message] =~ /has started|is being|off-line|shutdown/
+        cluster_name_long = "#{cluster_name} (#{aws_config[:region]}) #{events_record[:events][-1][:message]}"
+        maint_clusters.push(cluster_name_long) if events_record[:events][-1][:message] =~ /has started|is being|off-line|shutdown/
       end
     rescue => e
       unknown "An error occurred processing AWS RDS API: #{e.message}"


### PR DESCRIPTION
Adding RDS event message as output on check-rds-events.rb to provide
a bit more information on the event without having to log on
to AWS console to view it.