### PR TITLE
Generic CloudWatch Metric Check and Beanstalk Env Check

### DIFF
--- a/bin/check-beanstalk-elb-metric.rb
+++ b/bin/check-beanstalk-elb-metric.rb
@@ -32,56 +32,55 @@ require 'sensu-plugin/check/cli'
 require 'aws-sdk'
 
 class BeanstalkELBCheck < Sensu::Plugin::Check::CLI
-
   option :environment,
-          description: 'Application environment name',
-          short: '-e ENVIRONMENT_NAME',
-          long: '--environment ENVIRONMENT_NAME',
-          required: true
+         description: 'Application environment name',
+         short: '-e ENVIRONMENT_NAME',
+         long: '--environment ENVIRONMENT_NAME',
+         required: true
 
   option :elb_idx,
-          description: 'Index of ELB.  Useful for multiple ELB environments',
-          short: '-i ELB_NUM',
-          long: '--elb-idx ELB_NUM',
-          default: 0,
-          proc: proc(&:to_i)
+         description: 'Index of ELB.  Useful for multiple ELB environments',
+         short: '-i ELB_NUM',
+         long: '--elb-idx ELB_NUM',
+         default: 0,
+         proc: proc(&:to_i)
 
   option :metric_name,
-          description: 'ELB CloudWatch Metric',
-          short: '-m METRIC_NAME',
-          long: '--metric METRIC_NAME',
-          required: true
+         description: 'ELB CloudWatch Metric',
+         short: '-m METRIC_NAME',
+         long: '--metric METRIC_NAME',
+         required: true
 
   option :period,
-          description: 'CloudWatch metric statistics period. Must be a multiple of 60',
-          short:       '-p N',
-          long:        '--period SECONDS',
-          default:     60,
-          proc:        proc(&:to_i)
+         description: 'CloudWatch metric statistics period. Must be a multiple of 60',
+         short:       '-p N',
+         long:        '--period SECONDS',
+         default:     60,
+         proc:        proc(&:to_i)
 
   option :statistics,
-          short:       '-s N',
-          long:        '--statistics NAME',
-          default:     "Average",
-          description: 'CloudWatch statistics method'
+         short:       '-s N',
+         long:        '--statistics NAME',
+         default:     'Average',
+         description: 'CloudWatch statistics method'
 
   option :unit,
-          short:       '-u UNIT',
-          long:        '--unit UNIT',
-          description: 'CloudWatch metric unit'
+         short:       '-u UNIT',
+         long:        '--unit UNIT',
+         description: 'CloudWatch metric unit'
 
   option :critical,
-          description: 'Trigger a critical when value is over VALUE',
-          short: '-c VALUE',
-          long: '--critical VALUE',
-          proc:        proc(&:to_f),
-          required: true
+         description: 'Trigger a critical when value is over VALUE',
+         short: '-c VALUE',
+         long: '--critical VALUE',
+         proc:        proc(&:to_f),
+         required: true
 
   option :warning,
-          description: 'Trigger a critical when value is over VALUE',
-          short: '-w VALUE',
-          long: '--warning VALUE',
-          proc: proc(&:to_f)
+         description: 'Trigger a critical when value is over VALUE',
+         short: '-w VALUE',
+         long: '--warning VALUE',
+         proc: proc(&:to_f)
 
   option :compare,
          description: 'Comparision operator for threshold: equal, not, greater, less',
@@ -90,11 +89,11 @@ class BeanstalkELBCheck < Sensu::Plugin::Check::CLI
          default: 'greater'
 
   option :no_data_ok,
-        short: '-n',
-        long: '--allow-no-data',
-        description: 'Returns ok if no data is returned from the metric',
-        boolean: true,
-        default: false
+         short: '-n',
+         long: '--allow-no-data',
+         description: 'Returns ok if no data is returned from the metric',
+         boolean: true,
+         default: false
 
   include CloudwatchCommon
 
@@ -104,18 +103,18 @@ class BeanstalkELBCheck < Sensu::Plugin::Check::CLI
 
   def elb_name
     @elb_name ||= Aws::ElasticBeanstalk::Client.new
-      .describe_environment_resources({environment_name: config[:environment]})
-      .environment_resources
-      .load_balancers[config[:elb_idx]]
-      .name
+                  .describe_environment_resources(environment_name: config[:environment])
+                  .environment_resources
+                  .load_balancers[config[:elb_idx]]
+                  .name
   end
 
   def run
     new_config = config.clone
-    new_config[:namespace] = "AWS/ELB"
+    new_config[:namespace] = 'AWS/ELB'
     new_config[:dimensions] = [
       {
-        name: "LoadBalancerName",
+        name: 'LoadBalancerName',
         value: elb_name
       }
     ]

--- a/bin/check-beanstalk-elb-metric.rb
+++ b/bin/check-beanstalk-elb-metric.rb
@@ -99,7 +99,7 @@ class BeanstalkELBCheck < Sensu::Plugin::Check::CLI
   include CloudwatchCommon
 
   def metric_desc
-    @metric_desc ||= "BeanstalkELB/#{config[:environment]}/#{elb_name}/#{config[:metric]}"
+    @metric_desc ||= "BeanstalkELB/#{config[:environment]}/#{elb_name}/#{config[:metric_name]}"
   end
 
   def elb_name

--- a/bin/check-beanstalk-elb-metric.rb
+++ b/bin/check-beanstalk-elb-metric.rb
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
 #
-# check-cloudwatch-alarm
+# check-beanstalk-elb-metric
 #
 # DESCRIPTION:
 #   This plugin finds the desired ELB in a beanstalk environment and queries
@@ -53,27 +53,27 @@ class BeanstalkELBCheck < Sensu::Plugin::Check::CLI
 
   option :period,
          description: 'CloudWatch metric statistics period. Must be a multiple of 60',
-         short:       '-p N',
-         long:        '--period SECONDS',
-         default:     60,
-         proc:        proc(&:to_i)
+         short: '-p N',
+         long: '--period SECONDS',
+         default: 60,
+         proc: proc(&:to_i)
 
   option :statistics,
-         short:       '-s N',
-         long:        '--statistics NAME',
-         default:     'Average',
+         short: '-s N',
+         long: '--statistics NAME',
+         default: 'Average',
          description: 'CloudWatch statistics method'
 
   option :unit,
-         short:       '-u UNIT',
-         long:        '--unit UNIT',
+         short: '-u UNIT',
+         long: '--unit UNIT',
          description: 'CloudWatch metric unit'
 
   option :critical,
          description: 'Trigger a critical when value is over VALUE',
          short: '-c VALUE',
          long: '--critical VALUE',
-         proc:        proc(&:to_f),
+         proc: proc(&:to_f),
          required: true
 
   option :warning,

--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -1,0 +1,130 @@
+#! /usr/bin/env ruby
+#
+# check-cloudwatch-alarm
+#
+# DESCRIPTION:
+#   This plugin retrieves the value of a cloudwatch metric and triggers
+#   alarms based on the threshold's specified
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-cloudwatch-metric -n CPUUtilization -d InstanceId=i-12345678,AvailabilityZone=us-east-1a -c 90
+#
+# NOTES:
+#
+# LICENSE:
+#   Andrew Matheny
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'aws-sdk'
+
+class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
+
+  option :namespace,
+          description: 'CloudWatch namespace for metric',
+          short: '-n NAME',
+          long: '--namespace NAME',
+          default: "AWS/EC2"
+
+  option :metric_name,
+          description: 'Metric name',
+          short: '-m NAME',
+          long: '--metric NAME',
+          required: true
+
+  option :dimensions,
+          description: 'Comma delimited list of DimName=Value',
+          short: '-d DIMENSIONS',
+          long: '--dimensions DIMENSIONS',
+          proc: proc { |d| CloudWatchMetricCheck.parse_dimensions d },
+          default: ''
+
+  option :period,
+          description: 'CloudWatch metric statistics period. Must be a multiple of 60',
+          short:       '-p N',
+          long:        '--period SECONDS',
+          default:     60,
+          proc:        proc(&:to_i)
+
+  option :statistics,
+          short:       '-s N',
+          long:        '--statistics NAME',
+          default:     ["Average"],
+          proc: proc { |s| [s] },
+          description: 'CloudWatch statistics method'
+
+  option :unit,
+          short:       '-u UNIT',
+          long:        '--unit UNIT',
+          description: 'CloudWatch metric unit'
+
+  option :critical,
+          description: 'Trigger a critical when value is over VALUE',
+          short: '-c VALUE',
+          long: '--critical VALUE',
+          proc:        proc(&:to_f),
+          required: true
+
+  option :warning,
+          description: 'Trigger a critical when value is over VALUE',
+          short: '-w VALUE',
+          long: '--warning VALUE',
+          proc: proc(&:to_f)
+
+  def self.parse_dimensions(dimension_string)
+    dimension_string.split(',')
+      .collect { |d| d.split '=' }
+      .collect { |a| { name: a[0], value: a[1] } }
+  end
+
+  def dimension_string
+    config[:dimensions].map{|d| "#{d[:name]}=#{d[:value]}"}.join('&')
+  end
+
+  def client
+    @cloud_watch ||= Aws::CloudWatch::Client.new
+  end
+
+  def metric_desc
+    @metric_desc ||= "#{config[:namespace]}-#{config[:metric_name]}(#{dimension_string})"
+  end
+
+  def run
+    critical_threshold = config.delete(:critical)
+    warning_threshold = config.delete(:warning)
+
+    config[:start_time] = Time.now - config[:period]
+    config[:end_time] = Time.now
+
+    resp = client.get_metric_statistics(config)
+    if resp == nil or resp.datapoints == nil or resp.datapoints.length == 0
+      unknown "#{metric_desc} could not be retrieved"
+    end
+
+    value = resp.datapoints[0].send(config[:statistics][0].downcase)
+
+    if not value
+      unknown "#{metric_desc} could not be retrieved"
+    end
+    base_msg = "#{metric_desc} is #{value} which is "
+    if value >= critical_threshold
+      critical "#{base_msg} greater than #{critical_threshold}"
+    elsif warning_threshold and value >= warning_threshold
+      warning "#{base_msg} greater than #{warning_threshold}"
+    else
+      ok "#{base_msg} good"
+    end
+  end
+end

--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -32,56 +32,55 @@ require 'sensu-plugin/check/cli'
 require 'aws-sdk'
 
 class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
-
   option :namespace,
-          description: 'CloudWatch namespace for metric',
-          short: '-n NAME',
-          long: '--namespace NAME',
-          default: "AWS/EC2"
+         description: 'CloudWatch namespace for metric',
+         short: '-n NAME',
+         long: '--namespace NAME',
+         default: 'AWS/EC2'
 
   option :metric_name,
-          description: 'Metric name',
-          short: '-m NAME',
-          long: '--metric NAME',
-          required: true
+         description: 'Metric name',
+         short: '-m NAME',
+         long: '--metric NAME',
+         required: true
 
   option :dimensions,
-          description: 'Comma delimited list of DimName=Value',
-          short: '-d DIMENSIONS',
-          long: '--dimensions DIMENSIONS',
-          proc: proc { |d| CloudWatchMetricCheck.parse_dimensions d },
-          default: ''
+         description: 'Comma delimited list of DimName=Value',
+         short: '-d DIMENSIONS',
+         long: '--dimensions DIMENSIONS',
+         proc: proc { |d| CloudWatchMetricCheck.parse_dimensions d },
+         default: ''
 
   option :period,
-          description: 'CloudWatch metric statistics period. Must be a multiple of 60',
-          short:       '-p N',
-          long:        '--period SECONDS',
-          default:     60,
-          proc:        proc(&:to_i)
+         description: 'CloudWatch metric statistics period. Must be a multiple of 60',
+         short:       '-p N',
+         long:        '--period SECONDS',
+         default:     60,
+         proc:        proc(&:to_i)
 
   option :statistics,
-          short:       '-s N',
-          long:        '--statistics NAME',
-          default:     "Average",
-          description: 'CloudWatch statistics method'
+         short:       '-s N',
+         long:        '--statistics NAME',
+         default:     'Average',
+         description: 'CloudWatch statistics method'
 
   option :unit,
-          short:       '-u UNIT',
-          long:        '--unit UNIT',
-          description: 'CloudWatch metric unit'
+         short:       '-u UNIT',
+         long:        '--unit UNIT',
+         description: 'CloudWatch metric unit'
 
   option :critical,
-          description: 'Trigger a critical when value is over VALUE',
-          short: '-c VALUE',
-          long: '--critical VALUE',
-          proc:        proc(&:to_f),
-          required: true
+         description: 'Trigger a critical when value is over VALUE',
+         short: '-c VALUE',
+         long: '--critical VALUE',
+         proc:        proc(&:to_f),
+         required: true
 
   option :warning,
-          description: 'Trigger a critical when value is over VALUE',
-          short: '-w VALUE',
-          long: '--warning VALUE',
-          proc: proc(&:to_f)
+         description: 'Trigger a critical when value is over VALUE',
+         short: '-w VALUE',
+         long: '--warning VALUE',
+         proc: proc(&:to_f)
 
   option :compare,
          description: 'Comparision operator for threshold: equal, not, greater, less',
@@ -90,11 +89,11 @@ class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
          default: 'greater'
 
   option :no_data_ok,
-        short: '-n',
-        long: '--allow-no-data',
-        description: 'Returns ok if no data is returned from the metric',
-        boolean: true,
-        default: false
+         short: '-n',
+         long: '--allow-no-data',
+         description: 'Returns ok if no data is returned from the metric',
+         boolean: true,
+         default: false
 
   include CloudwatchCommon
 
@@ -105,7 +104,7 @@ class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
   end
 
   def dimension_string
-    config[:dimensions].map{|d| "#{d[:name]}=#{d[:value]}"}.join('&')
+    config[:dimensions].map { |d| "#{d[:name]}=#{d[:value]}" }.join('&')
   end
 
   def metric_desc

--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -118,7 +118,7 @@ class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
     if not value
       unknown "#{metric_desc} could not be retrieved"
     end
-    base_msg = "#{metric_desc} is #{value} which is "
+    base_msg = "#{metric_desc} is #{value} which is"
     if value >= critical_threshold
       critical "#{base_msg} greater than #{critical_threshold}"
     elsif warning_threshold and value >= warning_threshold

--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -1,10 +1,10 @@
 #! /usr/bin/env ruby
 #
-# check-cloudwatch-alarm
+# check-cloudwatch-metric
 #
 # DESCRIPTION:
 #   This plugin retrieves the value of a cloudwatch metric and triggers
-#   alarms based on the threshold's specified
+#   alarms based on the thresholds specified
 #
 # OUTPUT:
 #   plain-text
@@ -53,27 +53,27 @@ class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
 
   option :period,
          description: 'CloudWatch metric statistics period. Must be a multiple of 60',
-         short:       '-p N',
-         long:        '--period SECONDS',
-         default:     60,
-         proc:        proc(&:to_i)
+         short: '-p N',
+         long: '--period SECONDS',
+         default: 60,
+         proc: proc(&:to_i)
 
   option :statistics,
-         short:       '-s N',
-         long:        '--statistics NAME',
-         default:     'Average',
+         short: '-s N',
+         long: '--statistics NAME',
+         default: 'Average',
          description: 'CloudWatch statistics method'
 
   option :unit,
-         short:       '-u UNIT',
-         long:        '--unit UNIT',
+         short: '-u UNIT',
+         long: '--unit UNIT',
          description: 'CloudWatch metric unit'
 
   option :critical,
          description: 'Trigger a critical when value is over VALUE',
          short: '-c VALUE',
          long: '--critical VALUE',
-         proc:        proc(&:to_f),
+         proc: proc(&:to_f),
          required: true
 
   option :warning,

--- a/lib/sensu-plugins-aws/cloudwatch-common.rb
+++ b/lib/sensu-plugins-aws/cloudwatch-common.rb
@@ -1,0 +1,62 @@
+require 'aws-sdk'
+
+module CloudwatchCommon
+  def client
+    Aws::CloudWatch::Client.new
+  end
+
+  def read_value(resp, stats)
+    resp.datapoints.first.send(stats.downcase)
+  end
+
+  def resp_has_no_data(resp, stats)
+    resp.datapoints == nil or resp.datapoints.length == 0 or resp.datapoints.first == nil or read_value(resp, stats) == nil
+  end
+
+  def compare(value, threshold, compare_method)
+    if compare_method == 'greater'
+      return value > threshold
+    elsif compare_method == 'less'
+      return value < threshold
+    elsif compare_method == 'not'
+      return value != threshold
+    else
+      return value == threshold
+    end
+  end
+
+  def metrics_request(config)
+    {
+      namespace: config[:namespace],
+      metric_name: config[:metric_name],
+      dimensions: config[:dimensions],
+      start_time: Time.now - config[:period]*10,
+      end_time: Time.now,
+      period: config[:period],
+      statistics: [config[:statistics]],
+      unit: config[:unit]
+    }
+  end
+
+  def check(config)
+    resp = client.get_metric_statistics(metrics_request(config))
+
+    no_data = resp_has_no_data(resp, config[:statistics])
+    if no_data and config[:no_data_ok]
+      ok "#{metric_desc} returned no data but that's ok"
+    elsif no_data and not config[:no_data_ok]
+      unknown "#{metric_desc} could not be retrieved"
+    end
+
+    value = read_value(resp, config[:statistics])
+    base_msg = "#{metric_desc} is #{value}: comparison=#{config[:compare]}"
+
+    if compare value, config[:critical], config[:comparison]
+      critical "#{base_msg} threshold=#{config[:critical]}"
+    elsif config[:warning] and compare value, config[:warning], config[:comparison]
+      warning "#{base_msg} threshold=#{config[:warning]}"
+    else
+      ok "#{base_msg}, will alarm at #{config[:warning] != nil ? config[:warning] : config[:critical]}"
+    end
+  end
+end

--- a/lib/sensu-plugins-aws/cloudwatch-common.rb
+++ b/lib/sensu-plugins-aws/cloudwatch-common.rb
@@ -10,7 +10,7 @@ module CloudwatchCommon
   end
 
   def resp_has_no_data(resp, stats)
-    resp.datapoints == nil or resp.datapoints.length == 0 or resp.datapoints.first == nil or read_value(resp, stats) == nil
+    resp.datapoints.nil? || resp.datapoints.length == 0 || resp.datapoints.first.nil? || read_value(resp, stats).nil?
   end
 
   def compare(value, threshold, compare_method)
@@ -30,7 +30,7 @@ module CloudwatchCommon
       namespace: config[:namespace],
       metric_name: config[:metric_name],
       dimensions: config[:dimensions],
-      start_time: Time.now - config[:period]*10,
+      start_time: Time.now - config[:period] * 10,
       end_time: Time.now,
       period: config[:period],
       statistics: [config[:statistics]],
@@ -42,9 +42,9 @@ module CloudwatchCommon
     resp = client.get_metric_statistics(metrics_request(config))
 
     no_data = resp_has_no_data(resp, config[:statistics])
-    if no_data and config[:no_data_ok]
+    if no_data && config[:no_data_ok]
       ok "#{metric_desc} returned no data but that's ok"
-    elsif no_data and not config[:no_data_ok]
+    elsif no_data && !config[:no_data_ok]
       unknown "#{metric_desc} could not be retrieved"
     end
 
@@ -53,10 +53,10 @@ module CloudwatchCommon
 
     if compare value, config[:critical], config[:comparison]
       critical "#{base_msg} threshold=#{config[:critical]}"
-    elsif config[:warning] and compare value, config[:warning], config[:comparison]
+    elsif config[:warning] && compare(value, config[:warning], config[:comparison])
       warning "#{base_msg} threshold=#{config[:warning]}"
     else
-      ok "#{base_msg}, will alarm at #{config[:warning] != nil ? config[:warning] : config[:critical]}"
+      ok "#{base_msg}, will alarm at #{!config[:warning].nil? ? config[:warning] : config[:critical]}"
     end
   end
 end


### PR DESCRIPTION
Adds two new checks.  One to check a generic cloudwatch metric and another to check a specific metric on an elastic beanstalk ELB.