### PR TITLE
Several updates to check-ses-limit.  Backwards compatible.

### DIFF
--- a/bin/check-ses-limit.rb
+++ b/bin/check-ses-limit.rb
@@ -16,6 +16,7 @@
 # DEPENDENCIES:
 #   gem: aws-sdk
 #   gem: sensu-plugin
+#   gem: sensu-plugins-aws
 #
 # USAGE:
 #   #YELLOW
@@ -29,20 +30,20 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'aws/ses'
+require 'sensu-plugins-aws'
+require 'aws-sdk'
 
 class CheckSESLimit < Sensu::Plugin::Check::CLI
+  include Common
   option :aws_access_key,
          short: '-a AWS_ACCESS_KEY',
          long: '--aws-access-key AWS_ACCESS_KEY',
-         description: "AWS Access Key. Either set ENV['AWS_ACCESS_KEY'] or provide it as an option",
-         default: ENV['AWS_ACCESS_KEY']
+         description: 'AWS Access Key ID.'
 
   option :aws_secret_access_key,
          short: '-k AWS_SECRET_KEY',
          long: '--aws-secret-access-key AWS_SECRET_KEY',
-         description: "AWS Secret Access Key. Either set ENV['AWS_SECRET_KEY'] or provide it as an option",
-         default: ENV['AWS_SECRET_KEY']
+         description: 'AWS Secret Access Key.'
 
   option :aws_region,
          short: '-r AWS_REGION',
@@ -64,33 +65,25 @@ class CheckSESLimit < Sensu::Plugin::Check::CLI
          default: 90,
          proc: proc(&:to_i)
 
-  def aws_config
-    { access_key_id: config[:aws_access_key],
-      secret_access_key: config[:aws_secret_access_key],
-      region: config[:aws_region]
-    }
-  end
-
   def run
     begin
-      ses = AWS::SES::Base.new aws_config
-
-      response = ses.quota
-    rescue AWS::SES::ResponseError => e
-      critical "An issue occured while communicating with the AWS SES API: #{e.message}"
+      ses = Aws::SES::Client.new
+      response = ses.get_send_quota
+    rescue => e
+      unknown "An issue occured while communicating with the AWS SES API: #{e.message}"
     end
 
-    unless response.empty? # rubocop: disable Style/GuardClause
-      percent = (response.sent_last_24_hours.to_i / response.max_24_hour_send.to_i) * 100
-      message = "SES sending limit is at #{percent}%"
+    unknown 'Empty response from AWS SES API' if response.empty? # Can this happen?
 
-      if config[:crit_percent] > 0 && config[:crit_percent] <= percent
-        critical message
-      elsif config[:warn_percent] > 0 && config[:warn_percent] <= percent
-        warning message
-      else
-        ok message
-      end
+    percent = (response.sent_last_24_hours.to_i / response.max_24_hour_send.to_i) * 100
+    message = "SES sending limit is at #{percent}%"
+
+    if config[:crit_percent] > 0 && config[:crit_percent] <= percent
+      critical message
+    elsif config[:warn_percent] > 0 && config[:warn_percent] <= percent
+      warning message
+    else
+      ok message
     end
   end
 end


### PR DESCRIPTION
This is my first Github open source contribution.  I hope to make more here.

Multiple updates to check-ses-limit:
1) Use Common module per issue #1.  Btw, I think we should develop a common "check" method to evaluate X against critical, warning, and issue the proper ok, warning, critical output.  I don't know what all the requirements are, so I haven't proposed one.
2) Make credential passing via command line optional (although I would prefer not to support it at all) per issue #2.  This enables EC2 IAM role based authentication/authorization.
3) Change to sdk v2.
4) Use guard clause instead of conditional enclosure.
5) Return unknown for all errors not related to the checked value.  Should this be a convention?

Thank you for your consideration