### PR TITLE
adding global cpu balance check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## Unreleased
 ### Added
+- check-ec2-cpu_balance.rb: scans for any t2 instances that are below a certain threshold of cpu credits
 - check-elb-health-sdk.rb: add option for warning instead of critical when unhealthy instances are found
 - check-rds.rb: add M4 instances
 - handler-sns.rb: add option to use a template to render body mail

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 
 **check-ebs-snapshots.rb**
 
+**check-ec2-cpu_balance.rb**
+
 **check-ec2-filter.rb**
 
 **check-ec2-network.rb**

--- a/bin/check-ec2-cpu_balance.rb
+++ b/bin/check-ec2-cpu_balance.rb
@@ -1,0 +1,105 @@
+#! /usr/bin/env ruby
+#
+# check-ec2-cpu_balance
+#
+# DESCRIPTION:
+#   This plugin retrieves the value of the cpu balance for all servers
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-ec2-cpu_balance -c 20
+#
+# NOTES:
+#
+# LICENSE:
+#   Shane Starcher
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugins-aws'
+require 'sensu-plugin/check/cli'
+require 'aws-sdk'
+
+class EC2CpuBalance < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :critical,
+         description: 'Trigger a critical when value is below VALUE',
+         short: '-c VALUE',
+         long: '--critical VALUE',
+         proc: proc(&:to_f),
+         required: true
+
+  option :warning,
+         description: 'Trigger a warning when value is below VALUE',
+         short: '-w VALUE',
+         long: '--warning VALUE',
+         proc: proc(&:to_f)
+
+  option :aws_region,
+         short: '-r R',
+         long: '--region REGION',
+         description: 'AWS region',
+         default: 'us-east-1'
+
+  def data(instance)
+    client = Aws::CloudWatch::Client.new
+    stats = 'Average'
+    period = 60
+    resp = client.get_metric_statistics(
+      namespace: 'AWS/EC2',
+      metric_name: 'CPUCreditBalance',
+      dimensions: [{
+        name: 'InstanceId',
+        value: instance
+      }],
+      start_time: Time.now - period * 10,
+      end_time: Time.now,
+      period: period,
+      statistics: [stats]
+    )
+
+    return resp.datapoints.first.send(stats.downcase) unless resp.datapoints.first.nil?
+  end
+
+  def run
+    ec2 = Aws::EC2::Client.new
+    messages = []
+    level = 0
+    instances = ec2.describe_instances(
+      filters: [
+        {
+          name: 'instance-state-name',
+          values: ['running']
+        }
+      ])
+
+    instances.reservations.each do |reservation|
+      reservation.instances.each do |instance|
+        next unless instance.instance_type.start_with? 't2.'
+        id = instance.instance_id
+        result = data id
+        unless result.nil?
+          if result < config[:critical]
+            level = 2
+            messages << "#{id} is below critical threshold [#{config[:critical]} < #{result}]"
+          elsif config[:warning] && result < config[:warning]
+            level = 1 if level == 0
+            messages << "#{id} is below warning threshold [#{config[:warning]} < #{result}]"
+          end
+        end
+      end
+    end
+    fail SystemExit, level, messages
+  end
+end


### PR DESCRIPTION
We considered using the existing metric-check for CPU balance, but only t2/t1 servers actually have the cpu balance metric.  