### PR TITLE
Fixed ~10 rubocop offenses and rspec failure when environment unclean.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,12 @@ end
 
 RuboCop::RakeTask.new
 
+# Prevent environment pollution when running tests.
+ENV['AWS_SECRET_KEY'] = nil
+ENV['AWS_SECRET_ACCESS_KEY'] = nil
+ENV['AWS_ACCESS_KEY'] = nil
+ENV['AWS_ACCESS_KEY_ID'] = nil
+
 RSpec::Core::RakeTask.new(:spec) do |r|
   r.pattern = FileList['**/**/*_spec.rb']
 end

--- a/bin/check-autoscaling-cpucredits.rb
+++ b/bin/check-autoscaling-cpucredits.rb
@@ -98,9 +98,10 @@ class CheckEc2CpuCredits < Sensu::Plugin::Check::CLI
   end
 
   def get_count_metric(group)
-    cloud_watch.metrics
+    cloud_watch
+      .metrics
       .with_namespace('AWS/EC2')
-      .with_metric_name("#{config[:countmetric]}")
+      .with_metric_name(config[:countmetric].to_s)
       .with_dimensions(name: 'AutoScalingGroupName', value: group)
       .first
   end

--- a/bin/check-beanstalk-elb-metric.rb
+++ b/bin/check-beanstalk-elb-metric.rb
@@ -102,7 +102,8 @@ class BeanstalkELBCheck < Sensu::Plugin::Check::CLI
   end
 
   def elb_name
-    @elb_name ||= Aws::ElasticBeanstalk::Client.new
+    @elb_name ||= Aws::ElasticBeanstalk::Client
+                  .new
                   .describe_environment_resources(environment_name: config[:environment])
                   .environment_resources
                   .load_balancers[config[:elb_idx]]

--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -98,7 +98,8 @@ class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
   include CloudwatchCommon
 
   def self.parse_dimensions(dimension_string)
-    dimension_string.split(',')
+    dimension_string
+      .split(',')
       .collect { |d| d.split '=' }
       .collect { |a| { name: a[0], value: a[1] } }
   end

--- a/bin/check-ec2-network.rb
+++ b/bin/check-ec2-network.rb
@@ -95,7 +95,7 @@ class CheckEc2Network < Sensu::Plugin::Check::CLI
   end
 
   def network_metric(instance)
-    cloud_watch.metrics.with_namespace('AWS/EC2').with_metric_name("#{config[:direction]}").with_dimensions(name: 'InstanceId', value: instance).first
+    cloud_watch.metrics.with_namespace('AWS/EC2').with_metric_name(config[:direction].to_s).with_dimensions(name: 'InstanceId', value: instance).first
   end
 
   def statistics_options

--- a/bin/check-elb-health-fog.rb
+++ b/bin/check-elb-health-fog.rb
@@ -103,12 +103,10 @@ class ELBHealth < Sensu::Plugin::Check::CLI
       end
       if unhealthy_instances.empty?
         ok "All instances on ELB #{aws_region}::#{config[:elb_name]} healthy!"
+      elsif config[:verbose]
+        critical "Unhealthy instances detected: #{unhealthy_instances.map { |id, state| '[' + id + '::' + state + ']' }.join(' ')}"
       else
-        if config[:verbose]
-          critical "Unhealthy instances detected: #{unhealthy_instances.map { |id, state| '[' + id + '::' + state + ']' }.join(' ')}"
-        else
-          critical "Detected [#{unhealthy_instances.size}] unhealthy instances"
-        end
+        critical "Detected [#{unhealthy_instances.size}] unhealthy instances"
       end
     rescue => e
       warning "An issue occured while communicating with the AWS EC2 API: #{e.message}"

--- a/bin/metrics-elb-full.rb
+++ b/bin/metrics-elb-full.rb
@@ -118,7 +118,7 @@ class ELBMetrics < Sensu::Plugin::Metric::CLI::Graphite
       }
       config[:elbname].split(',').each do |elbname|
         if config[:scheme] == ''
-          graphitepath = "#{elbname}"
+          graphitepath = elbname.to_s
         else
           graphitepath = "#{config[:scheme]}.#{elbname}"
         end


### PR DESCRIPTION
When running `rake` on my Macbook with AWS keys configured in environment variables, tests fail and there are many Rubocop offenses. I fixed several of these issues. I can't fix ALL of the Rubocop offenses as my Ruby knowledge is not sufficient to know whether or not it should be followed :)