### PR TITLE
check-rds suppressing API errors

### DIFF
--- a/bin/check-rds.rb
+++ b/bin/check-rds.rb
@@ -135,10 +135,8 @@ class CheckRDS < Sensu::Plugin::Check::CLI
 
   def find_db_instance(id)
     db = rds.instances[id]
-    fail unless db.exists?
+    unknown 'DB instance not found.' unless db.exists?
     db
-  rescue
-    unknown 'DB instance not found.'
   end
 
   def cloud_watch_metric(metric_name)


### PR DESCRIPTION
We have had a few occurrences of 'DB instance not found.'  The DB certainly exists so it is likely an underlying API error is happening that is being blocked by this generic rescue block.