### PR TITLE
EC2 Node Handler broken for defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Fixed
 - check-vpc-vpn.rb: fix execution error by running with aws-sdk-v1
+- handler-ec2_node.rb: default values for ec2_states were ignored
 
 ## [2.1.0] - 2016-01-15
 ### Added

--- a/bin/handler-ec2_node.rb
+++ b/bin/handler-ec2_node.rb
@@ -154,13 +154,9 @@ class Ec2Node < Sensu::Handler
   def ec2_node_should_be_deleted?
     # Defining region for aws SDK object
     ec2 = Aws::EC2::Client.new(region: region)
-    # Check if attributes or json objects are not defined
-    if @event['client']['ec2_states'].nil? && settings['ec2_node']['ec2_states'].nil?
-      puts 'ec2_states is not define, please add the attributes or create a json config file with valid states keys'
-    else
-      # Asigning valid states
-      instance_states = @event['client']['ec2_states'] || settings['ec2_node']['ec2_states'] || ['shutting-down', 'terminated', 'stopping', 'stopped']
-    end
+    settings['ec2_node'] = {} unless settings['ec2_node']
+    instance_states = @event['client']['ec2_states'] || settings['ec2_node']['ec2_states'] || ['shutting-down', 'terminated', 'stopping', 'stopped']
+    instance_reasons = @event['client']['ec2_state_reasons'] || settings['ec2_node']['ec2_state_reasons'] || %w(Client.UserInitiatedShutdown Server.SpotInstanceTermination Client.InstanceInitiatedShutdown)
 
     begin
       # Finding the instance
@@ -172,16 +168,11 @@ class Ec2Node < Sensu::Handler
         # Checking for instance state and reason, and if matches any of the user defined or default reasons then
         # method returns True
 
-        # Returns Instance object
-        instance_obj = instances.instances[0]
         # Returns instance state reason in AWS i.e: "Client.UserInitiatedShutdown"
-        instance_state_reason = instance_obj.state_reason.code
+        instance_state_reason = instances.instances[0].state_reason.code
         # Returns the instance state i.e: "terminated"
-        instance_state = instance_obj.state.name
-        # Defining the default reasons why an instance could be deleted or not
-        instance_default_reasons = %w(Client.UserInitiatedShutdown Server.SpotInstanceTermination Client.InstanceInitiatedShutdown)
-        # If user specified a reason use those otherwise use default
-        instance_reasons = @event['client']['ec2_state_reasons'] || settings['ec2_node']['ec2_state_reasons'] || instance_default_reasons
+        instance_state = instances.instances[0].state.name
+
         # Return true is instance state and instance reason is valid
         instance_states.include?(instance_state) && instance_reasons.include?(instance_state_reason)
       end


### PR DESCRIPTION
fixing if statement logic.  With the if statement no defaults would ever be used.

I'm not sure why the previous changes were made to the EC2 Node handler, but they broke the logical defaults.

