### PR TITLE
added -i flag to check-ebs-snapshots to ignore volumes an IGNORE_BACKUP tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
+- check-ebs-snapshots.rb: added -i flag to ignore volumes that have an IGNORE_BACKUP tag.
 - check-sensu-client.rb Ensures that ec2 instances are registered with Sensu. 
 - check-trustedadvisor-service-limits.rb: New check for service limits based on Trusted Advisor API 
 

--- a/bin/check-ebs-snapshots.rb
+++ b/bin/check-ebs-snapshots.rb
@@ -18,8 +18,12 @@
 # USAGE:
 #   ./check-ebs-snapshots.rb -r ${you_region}
 #   ./check-ebs-snapshots.rb -r ${you_region} -p 1
+#   ./check-ebs-snapshots.rb -r ${you_region} -p -i
+#   ./check-ebs-snapshots.rb -r ${you_region} -i
 #
 # NOTES:
+#   When using -i flag any volume that has a tag-key of "IGNORE_BACKUP" will
+#   be ignored.
 #
 # LICENSE:
 #   Shane Starcher <shane.starcher@gmail.com>
@@ -45,11 +49,17 @@ class CheckEbsSnapshots < Sensu::Plugin::Check::CLI
          description: 'AWS region',
          default: 'us-east-1'
 
+  option :check_ignored,
+         short:       '-i',
+         long:        '--ignore',
+         description: 'mark as true to ignore volumes with an IGNORE_BACKUP tag',
+         boolean: true
+
   def run
     errors = []
-    ec2 = Aws::EC2::Client.new
+    @ec2 = Aws::EC2::Client.new
 
-    volumes = ec2.describe_volumes(
+    volumes = @ec2.describe_volumes(
       filters: [
         {
           name: 'attachment.status',
@@ -61,11 +71,10 @@ class CheckEbsSnapshots < Sensu::Plugin::Check::CLI
         }
       ]
     )
-
     volumes[:volumes].each do |volume|
+      next if config[:check_ignored] && ignored(volume)
       tags = volume[:tags].map { |a| Hash[*a] }.reduce(:merge) || {}
-
-      snapshots = ec2.describe_snapshots(
+      snapshots = @ec2.describe_snapshots(
         filters: [
           {
             name: 'volume-id',
@@ -90,5 +99,15 @@ class CheckEbsSnapshots < Sensu::Plugin::Check::CLI
     else
       warning errors.join("\n")
     end
+  end
+
+  def ignored(volume)
+    volume[:tags].each do |tag|
+      if tag[:key] == 'IGNORE_BACKUP'
+        puts "Ignoring volume with id: #{volume[:volume_id]}"
+        true
+      end
+    end
+    false
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [] Update README with any necessary configuration snippets
N/A

- [] Binstubs are created if needed
N/A

- [x] RuboCop passes

- [ ] Existing tests pass 

#### Purpose
To allow a user to exempt specific volumes from being checked in the check-ebs-snapshots.rb check

#### Known Compatablity Issues
