### PR TITLE
state_reason may not be defined by the API response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Implemented check for reserved instances
 - Added check to ensure that some or all AWS ConfigService rules have full compliance
 - Added check to ensure that sns subscriptions is not pending
+- handler-ec2_node.rb: protect from instance state_reason which may be nil
 
 ## [2.3.0] - 2016-03-18
 ### Added

--- a/bin/handler-ec2_node.rb
+++ b/bin/handler-ec2_node.rb
@@ -169,7 +169,7 @@ class Ec2Node < Sensu::Handler
         # method returns True
 
         # Returns instance state reason in AWS i.e: "Client.UserInitiatedShutdown"
-        instance_state_reason = instances.instances[0].state_reason == nil ? nil : instances.instances[0].state_reason.code
+        instance_state_reason = instances.instances[0].state_reason.nil? ? nil : instances.instances[0].state_reason.code
         # Returns the instance state i.e: "terminated"
         instance_state = instances.instances[0].state.name
 

--- a/bin/handler-ec2_node.rb
+++ b/bin/handler-ec2_node.rb
@@ -169,7 +169,7 @@ class Ec2Node < Sensu::Handler
         # method returns True
 
         # Returns instance state reason in AWS i.e: "Client.UserInitiatedShutdown"
-        instance_state_reason = instances.instances[0].state_reason.code
+        instance_state_reason = instances.instances[0].state_reason == nil ? nil : instances.instances[0].state_reason.code
         # Returns the instance state i.e: "terminated"
         instance_state = instances.instances[0].state.name
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

Protect against nil instance `state_reason`.

#### Known Compatablity Issues


