### PR TITLE
Fix --scheme option in metrics-sqs.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-sqs.rb: --scheme option now works with --prefix
+
 ### Added
 - check-sensu-clients.rb: SSL support
 

--- a/bin/metrics-sqs.rb
+++ b/bin/metrics-sqs.rb
@@ -74,7 +74,8 @@ class SQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def scheme(queue_name)
-    "aws.sqs.queue.#{queue_name.tr('-', '_')}.message_count"
+    scheme = config[:scheme].empty? ? 'aws.sqs.queue' : config[:scheme]
+    "#{scheme}.#{queue_name.tr('-', '_')}.message_count"
   end
 
   def run
@@ -86,14 +87,8 @@ class SQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
           critical 'Error, either QUEUE or PREFIX must be specified'
         end
 
-        scheme = if config[:scheme] == ''
-                   scheme config[:queue]
-                 else
-                   config[:scheme]
-                 end
-
         messages = sqs.queues.named(config[:queue]).approximate_number_of_messages
-        output scheme, messages
+        output scheme(config[:queue]), messages
       else
         sqs.queues.with_prefix(config[:prefix]).each do |q|
           queue_name = q.arn.split(':').last


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

The --scheme parameter in metrics-sqs.rb only worked with --queue option and not with --prefix, now it works with both.

#### Known Compatablity Issues

None

