### PR TITLE
Add a check for ECS service health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Added check to ensure that some or all AWS ConfigService rules have full compliance
 - Added check to ensure that sns subscriptions is not pending
 - handler-ec2_node.rb: protect from instance state_reason which may be nil
+- Added check to ensure that some or all ECS Services are healthy on a cluster
 
 ## [2.3.0] - 2016-03-18
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@
 
 **check-ec2-network.rb**
 
+**check-ecs-service-health.rb**
+
 **check-eip-allocation.rb**
 
 **check-elasticache-failover.rb**
@@ -62,7 +64,7 @@
 
 **check-redshift-events.rb**
 
-** check-reserved-instances.rb**
+**check-reserved-instances.rb**
 
 **check-s3-bucket.rb**
 
@@ -119,6 +121,7 @@
 * /bin/check-ebs-snapshots.rb
 * /bin/check-ec2-filter.rb
 * /bin/check-ec2-network.rb
+* /bin/check-ecs-service-health.rb
 * /bin/check-elasticache-failover.rb
 * /bin/check-elb-certs.rb
 * /bin/check-elb-health-fog.rb

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,7 @@ require 'rspec/core/rake_task'
 require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
+require 'English' # needed for $CHILD_STATUS vs $?
 
 desc 'Don\'t run Rubocop for unsupported versions'
 begin

--- a/bin/check-ecs-service-health.rb
+++ b/bin/check-ecs-service-health.rb
@@ -1,0 +1,111 @@
+#! /usr/bin/env ruby
+#
+# check-ecs-service-health
+#
+# DESCRIPTION:
+#   This plugin uses the AWS ECS API to check the running
+#   and desired task counts for services on a cluster.
+#   Any services with fewer running than desired tasks will
+#   are considered unhealthy.
+#
+#   CRIT: 0 = running < desired
+#   WARN: 0 < running < desired
+#   OK:   running >= desired
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux, Windows, Mac
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#  ./check-ecs-service-health.rb -r {us-east-1|eu-west-1} -c default [-s my-service]
+#
+# NOTES:
+#
+# LICENSE:
+#   Norm MacLennan <nmaclennan@cimpress.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+
+require 'sensu-plugin/check/cli'
+require 'sensu-plugins-aws'
+require 'aws-sdk'
+
+class CheckEcsServiceHealth < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region AWS_REGION',
+         description: 'The AWS region in which to check rules. Currently only available in us-east-1.',
+         default: 'us-east-1'
+
+  option :cluster_name,
+         short: '-c NAME',
+         long: '--cluster-name NAME',
+         description: 'The cluster to check services on.',
+         default: 'default'
+
+  option :services,
+         short: '-s SERVICE',
+         long: '--service NAME',
+         description: 'The service to check run status on.'
+
+  option :warn_as_crit,
+         short: '-w',
+         long: '--warn_as_crit',
+         description: 'Consider it critical when any desired tasks are not running. Otherwise, only 0 is critical.'
+
+  def ecs_client
+    @ecs_client ||= Aws::ECS::Client.new
+  end
+
+  # List of requested services or all services registered to the cluster
+  def service_list(cluster = 'default', services = nil)
+    return services.split ',' if services
+    ecs_client.list_services(cluster: cluster)['service_arns']
+  end
+
+  def service_details(cluster = 'default', services = nil)
+    ecs_client.describe_services(cluster: cluster, services: service_list(cluster, services))['services']
+  end
+
+  def bucket_service(running_count, desired_count)
+    if running_count == 0 && desired_count > 0
+      :critical
+    elsif running_count < desired_count
+      :warn
+    else
+      :ok
+    end
+  end
+
+  # Unhealthy if service has fewer running tasks than desired
+  def services_by_health(cluster = 'default', services = nil)
+    service_details(cluster, services).group_by { |s| bucket_service(s[:running_count], s[:desired_count]) }
+  end
+
+  def run
+    service_healths = services_by_health(config[:cluster_name], config[:services])
+
+    unhealthy = []
+    unhealthy.concat(service_healths[:critical]) if service_healths.key? :critical
+    unhealthy.concat(service_healths[:warn]) if service_healths.key? :warn
+    unhealthy = unhealthy.collect { |s| "#{s.service_name} (#{s.running_count}/#{s.desired_count})" }
+
+    if service_healths.key?(:critical) || (config[:warn_as_crit] && service_healths.key?(:warn))
+      critical("Unhealthy ECS Services: #{unhealthy.join ', '}")
+    elsif service_healths.key?(:warn)
+      warning("Unhealthy ECS Services: #{unhealthy.join ', '}")
+    else
+      ok
+    end
+  rescue => e
+    unknown "An error occurred processing AWS ECS API: #{e.message}"
+  end
+end

--- a/test/bin/check_ecs_service_health_spec.rb
+++ b/test/bin/check_ecs_service_health_spec.rb
@@ -1,0 +1,112 @@
+require_relative '../spec_helper.rb'
+require_relative '../../bin/check-ecs-service-health.rb'
+require_relative '../ecs_stubs.rb'
+
+describe 'CheckEcsServiceHealth' do
+  describe 'with full stub' do
+    before :all do
+      # Default stub contains a service in every possible state
+      stub_default
+    end
+
+    describe '#service_list' do
+      it 'should return all services by default' do
+        check = CheckEcsServiceHealth.new
+        services = check.service_list
+
+        expect(services).to eq(ALL_SERVICES.map { |s| s[:service_arn] })
+      end
+
+      it 'should return only services specified' do
+        check = CheckEcsServiceHealth.new
+
+        services = check.service_list(nil, 'my-broken-ecs-service')
+        expect(services).to eq(['my-broken-ecs-service'])
+      end
+    end
+
+    describe '#service_details' do
+      it 'should fetch details for all services by default' do
+        check = CheckEcsServiceHealth.new
+        services = check.service_details
+
+        expect(services.collect(&:service_arn)).to eq(ALL_SERVICES.map { |s| s[:service_arn] })
+      end
+    end
+
+    describe '#services_by_health' do
+      it 'should consider a service critical when none running but non-zero required' do
+        check = CheckEcsServiceHealth.new
+        services = check.services_by_health
+
+        expect(services[:critical].collect(&:service_name)).to eq([CRIT_SERVICE[:service_name]])
+      end
+
+      it 'should consider a service warning when 0 < running < desired' do
+        check = CheckEcsServiceHealth.new
+        services = check.services_by_health
+
+        expect(services[:warn].collect(&:service_name)).to eq([WARN_SERVICE[:service_name]])
+      end
+
+      it 'should consider a service okay when running >= desired' do
+        check = CheckEcsServiceHealth.new
+        services = check.services_by_health
+
+        expect(services[:ok].collect(&:service_name)).to eq([OK_SERVICE[:service_name], DISABLED_SERVICE[:service_name], DEPLOYING_SERVICE[:service_name]])
+      end
+    end
+
+    describe '#run' do
+      it 'should run and exit critical' do
+        check = CheckEcsServiceHealth.new
+        response = check.run
+
+        # The stubbed data includes a broken service, so we should CRIT
+        expect(response).to match(/^triggered critical(.*)my-broken-ecs-service(.*)$/)
+      end
+    end
+  end
+
+  describe 'with warning stub' do
+    before :all do
+      # Contains a service where 0 < desired < running
+      stub_warn
+    end
+
+    describe '#run' do
+      it 'should run and exit warn by default' do
+        check = CheckEcsServiceHealth.new
+        response = check.run
+
+        # The stubbed data includes a broken service, so we should WARN
+        expect(response).to match(/^triggered warning(.*)#{WARN_SERVICE[:service_name]}(.*)$/)
+      end
+
+      it 'should run and exit crit when warn_as_crit = true' do
+        check = CheckEcsServiceHealth.new
+        allow(check).to receive(:config).and_return(warn_as_crit: true)
+        response = check.run
+
+        # We should treat the warning service as critical due to config
+        expect(response).to match(/^triggered critical(.*)#{WARN_SERVICE[:service_name]}(.*)$/)
+      end
+    end
+  end
+
+  describe 'with ok stub' do
+    before :all do
+      # Contains two healthy services
+      stub_ok
+    end
+
+    describe '#run' do
+      it 'should run and exit ok' do
+        check = CheckEcsServiceHealth.new
+        response = check.run
+
+        expect(response).to match(/^triggered ok(.*)$/)
+      end
+    end
+  end
+end

--- a/test/ecs_stubs.rb
+++ b/test/ecs_stubs.rb
@@ -1,0 +1,121 @@
+require 'aws-sdk'
+
+DEPLOYING_SERVICE = {
+  service_arn: 'arn:aws:ecs:us-east-1:123456789012:service/my-deploying-ecs-service',
+  service_name: 'my-deploying-ecs-service',
+  cluster_arn: 'arn:aws:ecs:us-east-1:123456789012:cluster/default',
+  status: 'ACTIVE',
+  desired_count: 1,
+  running_count: 2,
+  pending_count: 0
+}.freeze
+
+OK_SERVICE = {
+  service_arn: 'arn:aws:ecs:us-east-1:123456789012:service/my-ecs-service',
+  service_name: 'my-healthy-ecs-service',
+  cluster_arn: 'arn:aws:ecs:us-east-1:123456789012:cluster/default',
+  status: 'ACTIVE',
+  desired_count: 1,
+  running_count: 1,
+  pending_count: 0
+}.freeze
+
+WARN_SERVICE = {
+  service_arn: 'arn:aws:ecs:us-east-1:123456789012:service/my-unstable-ecs-service',
+  service_name: 'my-unstable-ecs-service',
+  cluster_arn: 'arn:aws:ecs:us-east-1:123456789012:cluster/default',
+  status: 'ACTIVE',
+  desired_count: 2,
+  running_count: 1,
+  pending_count: 0
+}.freeze
+
+CRIT_SERVICE = {
+  service_arn: 'arn:aws:ecs:us-east-1:123456789012:service/my-broken-ecs-service',
+  service_name: 'my-broken-ecs-service',
+  cluster_arn: 'arn:aws:ecs:us-east-1:123456789012:cluster/default',
+  status: 'ACTIVE',
+  desired_count: 1,
+  running_count: 0,
+  pending_count: 0
+}.freeze
+
+DISABLED_SERVICE = {
+  service_arn: 'arn:aws:ecs:us-east-1:123456789012:service/my-disabled-ecs-service',
+  service_name: 'my-disabled-ecs-service',
+  cluster_arn: 'arn:aws:ecs:us-east-1:123456789012:cluster/default',
+  status: 'ACTIVE',
+  desired_count: 0,
+  running_count: 0,
+  pending_count: 0
+}.freeze
+
+ALL_SERVICES = [OK_SERVICE, WARN_SERVICE, CRIT_SERVICE, DISABLED_SERVICE, DEPLOYING_SERVICE].freeze
+
+def stub_default
+  describe_services = {
+    services: ALL_SERVICES
+  }
+
+  list_services = {
+    service_arns: describe_services[:services].collect { |s| s[:service_arn] }
+  }
+
+  Aws.config = {
+    stub_responses: {
+      describe_services: describe_services,
+      list_services: list_services
+    }
+  }
+end
+
+def stub_critical
+  describe_services = {
+    services: [CRIT_SERVICE]
+  }
+
+  list_services = {
+    service_arns: describe_services[:services].collect { |s| s[:service_arn] }
+  }
+
+  Aws.config = {
+    stub_responses: {
+      describe_services: describe_services,
+      list_services: list_services
+    }
+  }
+end
+
+def stub_warn
+  describe_services = {
+    services: [WARN_SERVICE]
+  }
+
+  list_services = {
+    service_arns: describe_services[:services].collect { |s| s[:service_arn] }
+  }
+
+  Aws.config = {
+    stub_responses: {
+      describe_services: describe_services,
+      list_services: list_services
+    }
+  }
+end
+
+def stub_ok
+  describe_services = {
+    services: [OK_SERVICE, DEPLOYING_SERVICE]
+  }
+
+  list_services = {
+    service_arns: describe_services[:services].collect { |s| s[:service_arn] }
+  }
+
+  Aws.config = {
+    stub_responses: {
+      describe_services: describe_services,
+      list_services: list_services
+    }
+  }
+end

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -30,19 +30,19 @@ module Common
     exit! 0
   end
 
-  def critical(msg)
+  def critical(msg = nil)
     "triggered critical: #{msg}"
   end
 
-  def warning(msg)
+  def warning(msg = nil)
     "triggered warning: #{msg}"
   end
 
-  def ok(msg)
+  def ok(msg = nil)
     "triggered ok: #{msg}"
   end
 
-  def unknown(*)
+  def unknown(msg = nil)
     "triggered unknown: #{msg}"
   end
 end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

This plugin uses the AWS ECS API to check the running
and desired task counts for services on a cluster.
Any services with fewer running than desired tasks will
are considered unhealthy.

    CRIT: 0 = running < desired
    WARN: 0 < running < desired
    OK:   running >= desired

#### Known Compatibility Issues

N/A