### PR TITLE
check-elb-health-sdk.rb - Added multi-region support and specify instance tag to display on check output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Added
 - Support for Ruby 2.3
+- check-elb-health-sdk.rb: Added multi-region support and specify instance tag to display on check output
 
 ## [2.4.3] - 2016-04-13
 ### Fixed


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Updated Changelog 

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose
In our use case, we have numerous ELBs across multiple regions that we have to monitor. Rather than defining a check for each ELB, it is more efficient to go through ELBs on every region within the account and alert only for unhealthy ELBs. The assumption here is that every ELB is expected to have 100% healthy instances behind it at all times.

Also, added the offending instance id and the ability to specify an optional instance tag to be included into the check output. 

For example, by adding `-t Name` argument, the check output will be as follow

ELBHealth CRITICAL: us-west-2: ELB-Name-XYZ unhealthy => [instance-id::instance-name::OutOfService] 

#### Known Compatablity Issues

