### PR TITLE
ignore completed instance-stop events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Removed
 - Support for Ruby 2.0
+- Ignore completed instance-stop ec2 events
 
 ### Added
 - Support for Ruby 2.3

--- a/bin/check-instance-events.rb
+++ b/bin/check-instance-events.rb
@@ -91,7 +91,7 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
         #         "not_after": "2015-01-05 18:00:00 UTC"
         #     }
         # ]
-        useful_events = i[:events_set].reject { |x| x[:code] == 'system-reboot' && x[:description] =~ /\[Completed\]/ }
+        useful_events = i[:events_set].reject { |x| (x[:code] == 'system-reboot' || x[:code] == 'instance-stop') && x[:description] =~ /\[Completed\]/ }
         unless useful_events.empty?
           event_instances << i[:instance_id]
         end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Completed ec2 instance-stop events were still showing as pending events.

#### Known Compatablity Issues


