### PR TITLE
add "Canceled" and "system-maintenace" status in check-instance-events.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Fixed
 - check-instance-events.rb: Ignore completed instance-stop ec2 events
+- check-instance-events.rb: Ignore canceled system-maintence ec2 events
 
 ## [3.0.0] - 2016-05-05
 ### Removed

--- a/bin/check-instance-events.rb
+++ b/bin/check-instance-events.rb
@@ -90,7 +90,8 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
         #         "not_after": "2015-01-05 18:00:00 UTC"
         #     }
         # ]
-        useful_events = i[:events_set].reject { |x| (x[:code] == 'system-reboot' || x[:code] == 'instance-stop' || x[:code] == 'system-maintenance' ) && (x[:description] =~ /\[Completed\]/ || x[:description] =~ /\[Canceled\]/ ) }
+        useful_events =
+          i[:events_set].reject { |x| (x[:code] == 'system-reboot' || x[:code] == 'instance-stop' || x[:code] == 'system-maintenance') && (x[:description] =~ /\[Completed\]/ || x[:description] =~ /\[Canceled\]/) }
         unless useful_events.empty?
           event_instances << i[:instance_id]
         end

--- a/bin/check-instance-events.rb
+++ b/bin/check-instance-events.rb
@@ -90,7 +90,7 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
         #         "not_after": "2015-01-05 18:00:00 UTC"
         #     }
         # ]
-        useful_events = i[:events_set].reject { |x| (x[:code] == 'system-reboot' || x[:code] == 'instance-stop') && x[:description] =~ /\[Completed\]/ }
+        useful_events = i[:events_set].reject { |x| (x[:code] == 'system-reboot' || x[:code] == 'instance-stop' || x[:code] == 'system-maintenance' ) && (x[:description] =~ /\[Completed\]/ || x[:description] =~ /\[Canceled\]/ ) }
         unless useful_events.empty?
           event_instances << i[:instance_id]
         end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [] Tests

- [] Add the plugin to the README

- [] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
add "Canceled" and "system-maintenace" status in check-instance-events.rb

#### Known Compatablity Issues
