### PR TITLE
Added all region support to a couple more checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - check-sensu-clients.rb: SSL support
 - check-rds-events.rb: Added '-r all' region support
-- check-instance-events.rb: Added '-r all' region support
+- check-instance-events.rb: Added '-r all' region support and description of the event
 - check-elb-health-sdk.rb: Added '-r all' support and specify instance tag to display on check output
 
 ## [3.1.0] - 2016-05-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Added
 - check-sensu-clients.rb: SSL support
+- check-rds-events.rb: Added '-r all' region support
+- check-instance-events.rb: Added '-r all' region support
+- check-elb-health-sdk.rb: Added '-r all' support and specify instance tag to display on check output
 
 ## [3.1.0] - 2016-05-15
 ### Fixed
@@ -31,7 +34,6 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Added
 - Support for Ruby 2.3
-- check-elb-health-sdk.rb: Added multi-region support and specify instance tag to display on check output
 - check-rds.rb: Added check for IOPS
 
 ## [2.4.3] - 2016-04-13

--- a/bin/check-elb-health-sdk.rb
+++ b/bin/check-elb-health-sdk.rb
@@ -90,14 +90,10 @@ class ELBHealth < Sensu::Plugin::Check::CLI
   end
 
   def ec2_regions
-    ec2_regions = []
+    # This is for SDK v2
+    # Aws.partition('aws').regions.map(&:name)
 
-    # this connection requires a region to start with. Use default us-east-1
-    aws_ec2 = AWS::EC2.new aws_config.merge(region: 'us-east-1')
-    aws_ec2.regions.each do |region|
-      ec2_regions.push(region.name)
-    end
-    ec2_regions
+    AWS::EC2.regions.map(&:name)
   end
 
   def elbs

--- a/bin/check-instance-events.rb
+++ b/bin/check-instance-events.rb
@@ -121,12 +121,12 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
               end
               event_instances << "#{name} (#{i[:instance_id]} #{r}) (#{i[:events_set][0][:code]}) #{i[:events_set][0][:description]}"
             else
-              event_instances << "(#{i[:instance_id]} #{r}) (#{i[:events_set][0][:code]}) #{i[:events_set][0][:description]}"
+              event_instances << "#{i[:instance_id]} (#{r}) (#{i[:events_set][0][:code]}) #{i[:events_set][0][:description]}"
             end
           end
         end
       rescue => e
-        unknown "An error occurred processing AWS EC2 API: #{e.message}"
+        unknown "An error occurred processing AWS EC2 API (#{r}): #{e.message}"
       end
     end
 

--- a/bin/check-instance-events.rb
+++ b/bin/check-instance-events.rb
@@ -112,8 +112,8 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
             i[:events_set].reject { |x| (x[:code] =~ /system-reboot|instance-stop|system-maintenance/) && (x[:description] =~ /\[Completed\]|\[Canceled\]/) }
           unless useful_events.empty?
             if config[:include_name]
+              name = ''
               begin
-                name = ''
                 instance_desc = ec2.describe_instances(instance_ids: [i[:instance_id]])
                 name = instance_desc[:reservation_index][i[:instance_id]][:instances_set][0][:tag_set].select { |tag| tag[:key] == 'Name' }[0][:value]
               rescue => e

--- a/bin/check-instance-events.rb
+++ b/bin/check-instance-events.rb
@@ -66,55 +66,68 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
       region: config[:aws_region] }
   end
 
+  def ec2_regions
+    # This is for SDK v2
+    # Aws.partition('aws').regions.map(&:name)
+
+    AWS::EC2.regions.map(&:name)
+  end
+
   def run
     event_instances = []
     aws_config = {}
+
+    aws_regions = ec2_regions
+
+    unless config[:aws_region].casecmp('all') == 0
+      if aws_regions.include? config[:aws_region]
+        aws_regions.clear.push(config[:aws_region])
+      else
+        critical 'Invalid region specified!'
+      end
+    end
 
     if config[:use_iam_role].nil?
       aws_config[:access_key_id] = config[:aws_access_key]
       aws_config[:secret_access_key] = config[:aws_secret_access_key]
     end
 
-    ec2 = AWS::EC2::Client.new(aws_config.merge!(region: config[:aws_region]))
-    begin
-      ec2.describe_instance_status[:instance_status_set].each do |i|
-        next if i[:events_set].empty?
+    aws_regions.each do |r| # Iterate each possible region
+      ec2 = AWS::EC2::Client.new(aws_config.merge!(region: r))
+      begin
+        ec2.describe_instance_status[:instance_status_set].each do |i|
+          next if i[:events_set].empty?
 
-        # Exclude completed reboots since the events API appearently returns these even after they have been completed:
-        # Example:
-        #  "events_set": [
-        #     {
-        #         "code": "system-reboot",
-        #         "description": "[Completed] Scheduled reboot",
-        #         "not_before": "2015-01-05 12:00:00 UTC",
-        #         "not_after": "2015-01-05 18:00:00 UTC"
-        #     }
-        # ]
-        useful_events =
-          i[:events_set].reject { |x| (x[:code] == 'system-reboot' || x[:code] == 'instance-stop' || x[:code] == 'system-maintenance') && (x[:description] =~ /\[Completed\]/ || x[:description] =~ /\[Canceled\]/) }
-        unless useful_events.empty?
-          event_instances << i[:instance_id]
+          # Exclude completed reboots since the events API appearently returns these even after they have been completed:
+          # Example:
+          #  "events_set": [
+          #     {
+          #         "code": "system-reboot",
+          #         "description": "[Completed] Scheduled reboot",
+          #         "not_before": "2015-01-05 12:00:00 UTC",
+          #         "not_after": "2015-01-05 18:00:00 UTC"
+          #     }
+          # ]
+          useful_events =
+            i[:events_set].reject { |x| (x[:code] =~ /system-reboot|instance-stop|system-maintenance/) && (x[:description] =~ /\[Completed\]|\[Canceled\]/) }
+          unless useful_events.empty?
+            if config[:include_name]
+              begin
+                name = ''
+                instance_desc = ec2.describe_instances(instance_ids: [i[:instance_id]])
+                name = instance_desc[:reservation_index][i[:instance_id]][:instances_set][0][:tag_set].select { |tag| tag[:key] == 'Name' }[0][:value]
+              rescue => e
+                puts "Issue getting instance details for #{i[:instance_id]} (#{r}).  Exception = #{e}"
+              end
+              event_instances << "#{name} (#{i[:instance_id]} #{r}) (#{i[:events_set][0][:code]}) #{i[:events_set][0][:description]}"
+            else
+              event_instances << "(#{i[:instance_id]} #{r}) (#{i[:events_set][0][:code]}) #{i[:events_set][0][:description]}"
+            end
+          end
         end
+      rescue => e
+        unknown "An error occurred processing AWS EC2 API: #{e.message}"
       end
-    rescue => e
-      unknown "An error occurred processing AWS EC2 API: #{e.message}"
-    end
-
-    if config[:include_name]
-      event_instances_with_names = []
-      event_instances.each do |id|
-        name = ''
-        begin
-          instance = ec2.describe_instances(instance_ids: [id])
-          # Harvests the 'Name' tag for the instance
-          name = instance[:reservation_index][id][:instances_set][0][:tag_set].select { |tag| tag[:key] == 'Name' }[0][:value]
-        rescue => e
-          puts "Issue getting instance details for #{id}.  Exception = #{e}"
-        end
-        # Pushes 'name(i-xxx)' if the Name tag was found, else it just pushes the id
-        event_instances_with_names << (name == '' ? id : "#{name}(#{id})")
-      end
-      event_instances = event_instances_with_names
     end
 
     if event_instances.count > 0


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
Added all region support (`-r all`) to a couple of checks to summarize alerts, instead of running identical checks multiple times across different regions. This can be handy when you are managing multiple accounts with multiple regions. 

- check-rds-events.rb: Added '-r all' region support
- check-instance-events.rb: Added '-r all' region support and description of the event
- check-elb-health-sdk.rb: Added '-r all' support and specify instance tag to display on check output

Also, fixed up CHANGELOG details that got messed up from previous PR rebase.