### PR TITLE
Current at_exit override has it always exiting 0 which breaks spec tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,3 +34,7 @@ Style/Next:
 
 Style/FormatString:
   Enabled: false
+
+Style/ClassVars:
+  Exclude:
+    - test/**/*.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-ecs-service-health.rb:
   - `service_list` retrieves all records when services not provided through options
   - `service_details` - handles scenario whereby services array is greater than aws limit (10)
+- exit code for tests did not respect rspec exit codes due to autorun feature. (#133 @zbintliff)
 
 ### Added
 - check-sensu-clients.rb: SSL support

--- a/sensu-plugins-aws.gemspec
+++ b/sensu-plugins-aws.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'aws-sdk-v1',        '1.66.0'
   s.add_runtime_dependency 'fog',               '1.32.0'
   s.add_runtime_dependency 'right_aws',         '3.1.0'
-  s.add_runtime_dependency 'sensu-plugin',      '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin',      '~> 1.3'
   s.add_runtime_dependency 'erubis',            '2.7.0'
   s.add_runtime_dependency 'rest-client',       '1.8.0'
 

--- a/test/bin/check_certifcate_expiry_spec.rb
+++ b/test/bin/check_certifcate_expiry_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper.rb'
 
 class CheckCertificateExpiry
   at_exit do
-    exit! 0
+    @@autorun = false
   end
 
   def critical(*)

--- a/test/bin/check_kms_key_spec.rb
+++ b/test/bin/check_kms_key_spec.rb
@@ -4,7 +4,7 @@ require_relative '../spec_helper.rb'
 
 class CheckKMSKey
   at_exit do
-    exit! 0
+    @@autorun = false
   end
 
   def critical(*)


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
Current tests for `checks` (not handles) override the `at_exit` function to `exit! 0`.  This stops spec exiting with proper exit codes when error is encountered.  In version 1.3.0 of sensu-plugin this PR https://github.com/sensu-plugins/sensu-plugin/commit/d6c6c33781dc474f189624fb6a06233e43eb6efd was added to check if `@@autorun` has a value.  This follows the behavior of handlers and mutators.

#### Known Compatablity Issues

None
