### PR TITLE
Additional per-queue SQS metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ### Added
 - check-sensu-clients.rb: SSL support
 - common.rb: adding support for environment variable AWS_REGION when region is specified as an empty string
+- metrics-sqs.rb: Add support for recording additional per-queue SQS metrics (counts of not-visible and delayed messages)
 
 ## [3.1.0] - 2016-05-15
 ### Fixed


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose

This PR adds collection of additional per-queue SQS metrics. In addition to the existing check for `approximate_number_of_messages` 2 additional metrics are collected (`approximate_number_of_messages_delayed` and `approximate_number_of_messages_not_visible`).

#### Known Compatibility Issues

None
