### PR TITLE
Add instance id option to `check-instance-events.rb`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - syntax error in check-sensu-clients
 
 ### Added
+- check-instance-events.rb: Add instance_id option
 - check-sensu-clients.rb: SSL support
 - common.rb: adding support for environment variable AWS_REGION when region is specified as an empty string
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [n/a] Update README with any necessary configuration snippets

- [n/a] Binstubs are created if needed

- [x] RuboCop passes

- [X] Existing tests pass 


#### Purpose
Add `instance_id` option to check-instance-events.rb. This allows our monitoring stack to create monitors/alerts for each ec2 instance. 

#### Known Compatibility Issues
None known

