### PR TITLE
New check script: check-subnet-ip-consumption.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-sensu-clients.rb: SSL support
 - common.rb: adding support for environment variable AWS_REGION when region is specified as an empty string
 - metrics-sqs.rb: Add support for recording additional per-queue SQS metrics (counts of not-visible and delayed messages)
+- check-subnet-ip-consumption.rb: to check consumption of IP addresses in subnets and alert if consumption exceeds a threshold
 
 ## [3.1.0] - 2016-05-15
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@
 
 **check-sqs-messages.rb**
 
+**check-subnet-ip-consumption**
+
 **check-vpc-nameservers**
 
 **check_vpc_vpn.py**
@@ -151,6 +153,7 @@
 * /bin/check-ses-limit.rb
 * /bin/check-ses-statistics.rb
 * /bin/check-sqs-messages.rb
+* /bin/check-subnet-ip-consumption.rb
 * /bin/check-vpc-nameservers.rb
 * /bin/check_vpc_vpn.py
 * /bin/check_vpc_vpn.rb

--- a/bin/check-subnet-ip-consumption.rb
+++ b/bin/check-subnet-ip-consumption.rb
@@ -38,16 +38,6 @@ require 'aws-sdk'
 class CheckSubnetIpConsumption < Sensu::Plugin::Check::CLI
   include Common
 
-  option :aws_access_key,
-         short:       '-a AWS_ACCESS_KEY',
-         long:        '--aws-access-key AWS_ACCESS_KEY',
-         description: 'AWS Access Key ID.'
-
-  option :aws_secret_access_key,
-         short:       '-k AWS_SECRET_KEY',
-         long:        '--aws-secret-access-key AWS_SECRET_KEY',
-         description: 'AWS Secret Access Key.'
-
   option :aws_region,
          short:       '-r AWS_REGION',
          long:        '--aws-region REGION',
@@ -85,18 +75,11 @@ class CheckSubnetIpConsumption < Sensu::Plugin::Check::CLI
          description: 'Manipulate the verbosity of the alert output. Valid options are 0, 1, and 2 (from least to most verbose). Default is 0.'
 
   def iam_client
-    @iam_client ||= Aws::IAM::Client.new(aws_config)
+    @iam_client ||= Aws::IAM::Client.new
   end
 
   def ec2_client
-    @ec2_client ||= Aws::EC2::Client.new(aws_config)
-  end
-
-  # Stores configuration values for the AWS SDK
-  def aws_config
-    { access_key_id: config[:aws_access_key],
-      secret_access_key: config[:aws_secret_access_key],
-      region: config[:aws_region] }
+    @ec2_client ||= Aws::EC2::Client.new
   end
 
   # Returns the alias of the AWS account (if there is one), "<no name>" (if there is not), or nil if -s/--show-account-alias is not used.

--- a/bin/check-subnet-ip-consumption.rb
+++ b/bin/check-subnet-ip-consumption.rb
@@ -1,0 +1,246 @@
+#! /usr/bin/env ruby
+#
+# check-subnet-ip-consumption
+#
+#
+# DESCRIPTION:
+#   This plugin uses the EC2 API to determine if any subnet in a given region
+#   has consumed IP addresses such that the consumption exceeds a user-specified threshold.
+#   This plugin additionally uses the IAM API to resolve the account alias,
+#   if the user uses the -s/--show-account-alias flag.
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#   gem: sensu-plugins-aws
+#
+# USAGE:
+#  ./check-subnet-ip-consumption.rb -a <access key> -k <secret key> -r <region> -t <integer percentage>
+#
+# NOTES:
+#   Special thanks to Garrett Kuchta and Antonio Beyah for their assistance.
+#
+# LICENSE:
+#   Nick Jacques <Nick.Jacques@target.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+
+require 'sensu-plugin/check/cli'
+require 'sensu-plugins-aws'
+require 'aws-sdk'
+
+class CheckSubnetIpConsumption < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :aws_access_key,
+         short:       '-a AWS_ACCESS_KEY',
+         long:        '--aws-access-key AWS_ACCESS_KEY',
+         description: 'AWS Access Key ID.'
+
+  option :aws_secret_access_key,
+         short:       '-k AWS_SECRET_KEY',
+         long:        '--aws-secret-access-key AWS_SECRET_KEY',
+         description: 'AWS Secret Access Key.'
+
+  option :aws_region,
+         short:       '-r AWS_REGION',
+         long:        '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default:     'us-east-1'
+
+  option :alert_threshold,
+         short:       '-t <threshold percentage>',
+         long:        '--threshold <threshold percentage>',
+         proc:        proc { |a| a.to_i },
+         default:     85,
+         in:          (0..100).to_a,
+         description: 'Threshold (in percent) of consumed IP addresses (per subnet) to alert on'
+
+  option :show_friendly_names,
+         short:       '-f',
+         long:        '--show-friendly-names',
+         boolean:     true,
+         default:     false,
+         description: 'Show friendly names (using the Name tag) for AWS objects such as subnets or VPCs'
+
+  option :show_account_alias,
+         short:       '-s',
+         long:        '--show-account-alias',
+         boolean:     true,
+         default:     false,
+         description: 'Show the account alias in the alert output. Requires IAM read privileges.'
+
+  option :verbosity,
+         short:       '-v <level>',
+         long:        '--verbosity <level>',
+         proc:        proc { |a| a.to_i },
+         in:          (0..2).to_a,
+         default:     0,
+         description: 'Manipulate the verbosity of the alert output. Valid options are 0, 1, and 2 (from least to most verbose). Default is 0.'
+
+  def iam_client
+    @iam_client ||= Aws::IAM::Client.new(aws_config)
+  end
+
+  def ec2_client
+    @ec2_client ||= Aws::EC2::Client.new(aws_config)
+  end
+
+  # Stores configuration values for the AWS SDK
+  def aws_config
+    { access_key_id: config[:aws_access_key],
+      secret_access_key: config[:aws_secret_access_key],
+      region: config[:aws_region] }
+  end
+
+  # Returns the alias of the AWS account (if there is one), "<no name>" (if there is not), or nil if -s/--show-account-alias is not used.
+  def account_alias
+    # Do not execute IAM API call unless the -s/--show_account_alias flag is specified
+    # (to prevent excess API calls *and* errors if IAM rights are not allowed)
+    return nil unless config[:show_account_alias]
+
+    begin
+      iam_account_alias = iam_client.list_account_aliases[:account_aliases].first
+
+      return '<no alias>' if iam_account_alias.empty? || iam_account_alias.nil?
+      return iam_account_alias
+    rescue => e
+      unknown "An error occured while using AWS IAM to collect the account alias: #{e.message}"
+    end
+  end
+
+  # Returns the value of the Name tag (if there is one) or "<no name>" (if there is not). Used with VPC and subnet objects.
+  def extract_name_tag(tags)
+    # Find the 'Name' key in the tags object and extract it. If the key isn't found, we get nil instead.
+    name_tag = tags.find { |tag| tag.key == 'Name' }
+    # If extracting the key/value was successful...
+    if name_tag
+      # ...extract the value (if there is one), or return <no name>
+      !name_tag[:value].empty? ? name_tag[:value] : '<no name>'
+    else
+      # Otherwise, there's not a Name key, and thus the object has no name.
+      '<no name>'
+    end
+  end
+
+  # Returns the subnet's friendly name if -f/--show-friendly-names is used, otherwise returns the ID
+  def display_subnet(alert)
+    return alert[:subnet_name] if config[:show_friendly_names]
+    alert[:subnet_id]
+  end
+
+  # Returns the VPC's friendly name if -f/--show-friendly-names is used, otherwise returns the ID
+  def display_vpc(alert)
+    return alert[:vpc_friendly_name] if config[:show_friendly_names]
+    alert[:subnet_vpc_id]
+  end
+
+  def run
+    # Subnets that meet the threshold criteria will store info hashes in this array
+    consumption_alert = []
+
+    begin
+      subnets = ec2_client.describe_subnets[:subnets]
+
+      subnets.each do |subnet|
+        # subnet.cidr_block contains '0.0.0.0/0' notation. We want the mask number after the slash.
+        subnet_netblock = subnet.cidr_block.split('/')[1].to_i
+        # Subtract the mask number from 32 and use the result as the exponent of 2 to get the number of possible addresses in the netblock.
+        # Then, subtract 5 from that number. Rationale: http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/VPC_Subnets.html#VPC_Sizing
+        # AWS reserves the first four addresses and the last address in any netblock.
+        subnet_total_capacity = (2**(32 - subnet_netblock)) - 5
+        # Determine how many IP addresses have been consumed
+        subnet_consumed_capacity = (subnet_total_capacity - subnet.available_ip_address_count)
+        # Divide consumed IPs by total IPs to get percentage. Multiply by 100 and round to get integer percents.
+        subnet_consumed_pct = ((subnet_consumed_capacity.to_f / subnet_total_capacity.to_f) * 100).round(0)
+
+        # Get the subnet's friendly name
+        subnet_name_tag = extract_name_tag subnet[:tags]
+        # Only get the VPC friendly names if explicitly asked for (otherwise this is a useless API hit)
+        if config[:show_friendly_names]
+          vpc = ec2_client.describe_vpcs(vpc_ids: [subnet.vpc_id])[:vpcs].first
+          vpc_friendly_name = extract_name_tag vpc[:tags]
+        end
+
+        # Test if the subnet consumption % meets or exceeds the threshold %
+        if subnet_consumed_pct >= config[:alert_threshold]
+          # Add a hash containing subnet info to the consumption_alert array
+          consumption_alert.push(subnet_id: subnet.subnet_id,
+                                 subnet_name: subnet_name_tag,
+                                 subnet_consumed_pct: subnet_consumed_pct,
+                                 subnet_vpc_id: subnet.vpc_id,
+                                 subnet_consumed_capacity: subnet_consumed_capacity,
+                                 subnet_total_capacity: subnet_total_capacity,
+                                 subnet_az: subnet[:availability_zone],
+                                 cidr_block: subnet[:cidr_block],
+                                 vpc_friendly_name: vpc_friendly_name)
+        end
+      end
+    rescue => e
+      unknown "An error occurred processing AWS EC2: #{e.message}"
+    end
+
+    # Process any alerts that might've been generated.
+    if consumption_alert.empty?
+      ok
+    else
+      # Compose alert messages at the configured verbosity
+      alert_msg = []
+
+      verbosity0 = '%{subnet} at %{percent}%% [%{vpc}]'
+      verbosity1 = '%{subnet} at %{percent}%% (%{consumed}/%{total}) [%{vpc}]'
+      verbosity2 = '%{subnet} (%{cidr} in %{az}) at %{percent}%% (%{consumed}/%{total}) [%{vpc}]'
+
+      case config[:verbosity]
+      when 0
+        consumption_alert.each do |alert|
+          alert_msg.push(verbosity0 % { subnet: (display_subnet alert).to_s,
+                                        percent: alert[:subnet_consumed_pct],
+                                        vpc: (display_vpc alert).to_s })
+        end
+      when 1
+        consumption_alert.each do |alert|
+          alert_msg.push(verbosity1 % { subnet: (display_subnet alert).to_s,
+                                        percent: alert[:subnet_consumed_pct],
+                                        consumed: alert[:subnet_consumed_capacity],
+                                        total: alert[:subnet_total_capacity],
+                                        vpc: (display_vpc alert).to_s })
+        end
+      when 2
+        consumption_alert.each do |alert|
+          alert_msg.push(verbosity2 % { subnet: (display_subnet alert).to_s,
+                                        cidr: alert[:cidr_block],
+                                        az: alert[:subnet_az],
+                                        percent: alert[:subnet_consumed_pct],
+                                        consumed: alert[:subnet_consumed_capacity],
+                                        total: alert[:subnet_total_capacity],
+                                        vpc: (display_vpc alert).to_s })
+        end
+      end
+
+      # Throw critical alert with optional account alias display
+      alert_prefix = '%{count} subnets in %{region} exceeding %{threshold}%% IP consumption threshold: %{alerts}'
+      alert_prefix_with_alias = '%{count} subnets in %{alias} (%{region}) exceeding %{threshold}%% IP consumption threshold: %{alerts}'
+
+      case config[:show_account_alias]
+      when true
+        critical(alert_prefix_with_alias % { count: alert_msg.length,
+                                             alias: account_alias,
+                                             region: config[:aws_region],
+                                             threshold: config[:alert_threshold],
+                                             alerts: alert_msg.join(', ') })
+      when false
+        critical(alert_prefix % { count: alert_msg.length,
+                                  region: config[:aws_region],
+                                  threshold: config[:alert_threshold],
+                                  alerts: alert_msg.join(', ') })
+      end
+    end
+  end
+end

--- a/test/bin/check_subnet_ip_consumption_spec.rb
+++ b/test/bin/check_subnet_ip_consumption_spec.rb
@@ -67,22 +67,6 @@ describe 'CheckSubnetIpConsumption' do
       subnet_az: 'us-east-1c', cidr_block: '192.168.99.0', vpc_friendly_name: '<no name>' }
   end
 
-  describe '#aws_config' do
-    context 'with defaults' do
-      it 'returns us-east-1 region' do
-        check = CheckSubnetIpConsumption.new
-        expect(check.aws_config[:region]).to eq('us-east-1')
-      end
-    end
-    context 'with user-specified region' do
-      it 'returns us-west-2 region' do
-        check = CheckSubnetIpConsumption.new
-        check.config[:aws_region] = 'us-west-2'
-        expect(check.aws_config[:region]).to eq('us-west-2')
-      end
-    end
-  end
-
   describe '#ec2_client' do
     it 'a valid EC2 client exists' do
       check = CheckSubnetIpConsumption.new

--- a/test/bin/check_subnet_ip_consumption_spec.rb
+++ b/test/bin/check_subnet_ip_consumption_spec.rb
@@ -1,0 +1,269 @@
+require 'aws-sdk'
+require 'ostruct'
+require_relative '../../bin/check-subnet-ip-consumption.rb'
+require_relative '../spec_helper.rb'
+
+class CheckSubnetIpConsumption
+  at_exit do
+    @@autorun = false
+  end
+
+  def critical(*)
+    'triggered critical'
+  end
+
+  def warning(*)
+    'triggered warning'
+  end
+
+  def ok(*)
+    'triggered ok'
+  end
+
+  def unknown(*)
+    'triggered unknown'
+  end
+end
+
+describe 'CheckSubnetIpConsumption' do
+  before :all do
+    @subnets = {
+      subnets: [
+        { subnet_id: 'subnet-test0123',
+          state: 'available',
+          cidr_block: '192.168.1.0/24',
+          vpc_id: 'vpc-12345678',
+          available_ip_address_count: 251,
+          availability_zone: 'us-east-1a',
+          tags: [{ key: 'Name', value: 'my_test_0123' }] }
+      ]
+    }
+    @vpcs = {
+      vpcs: [
+        { vpc_id: 'vpc-12345678',
+          state: 'available',
+          cidr_block: '192.168.1.0/20',
+          instance_tenancy: 'default',
+          is_default: true,
+          tags: [{ key: 'Name', value: 'my_vpc_12345678' }] }
+      ]
+    }
+    Aws.config[:iam] = { stub_responses: {
+      list_account_aliases: { account_aliases: ['my_account'] }
+    } }
+    Aws.config[:ec2] = { stub_responses: {
+      describe_subnets: @subnets,
+      describe_vpcs: @vpcs
+    } }
+  end
+  let(:test_alert) do
+    { subnet_id: 'subnet-00000000', subnet_name: 'subnet_name', subnet_consumed_pct: 60,
+      subnet_vpc_id: 'vpc-00000000', subnet_consumed_capacity: 151, subnet_total_capacity: 251,
+      subnet_az: 'us-east-1c', cidr_block: '192.168.99.0', vpc_friendly_name: 'vpc_name' }
+  end
+  let(:test_alert_with_no_names) do
+    { subnet_id: 'subnet-00000000', subnet_name: '<no name>', subnet_consumed_pct: 60,
+      subnet_vpc_id: 'vpc-00000000', subnet_consumed_capacity: 151, subnet_total_capacity: 251,
+      subnet_az: 'us-east-1c', cidr_block: '192.168.99.0', vpc_friendly_name: '<no name>' }
+  end
+
+  describe '#aws_config' do
+    context 'with defaults' do
+      it 'returns us-east-1 region' do
+        check = CheckSubnetIpConsumption.new
+        expect(check.aws_config[:region]).to eq('us-east-1')
+      end
+    end
+    context 'with user-specified region' do
+      it 'returns us-west-2 region' do
+        check = CheckSubnetIpConsumption.new
+        check.config[:aws_region] = 'us-west-2'
+        expect(check.aws_config[:region]).to eq('us-west-2')
+      end
+    end
+  end
+
+  describe '#ec2_client' do
+    it 'a valid EC2 client exists' do
+      check = CheckSubnetIpConsumption.new
+      expect(check.ec2_client).to_not be_nil
+    end
+  end
+
+  describe '#iam_client' do
+    it 'a valid IAM client exists' do
+      check = CheckSubnetIpConsumption.new
+      expect(check.iam_client).to_not be_nil
+    end
+  end
+
+  describe '#account_alias' do
+    context 'with a valid account alias' do
+      it 'returns nil when show_account_alias is false' do
+        check = CheckSubnetIpConsumption.new
+        expect(check.account_alias).to eq(nil)
+      end
+      it 'returns an account alias when show_account_alias is true' do
+        check = CheckSubnetIpConsumption.new
+        check.config[:show_account_alias] = true
+        expect(check.account_alias).to eq('my_account')
+      end
+    end
+    context 'with an empty account alias' do
+      before :all do
+        Aws.config[:iam] = { stub_responses: {
+          list_account_aliases: { account_aliases: [''] }
+        } }
+      end
+      it 'returns nil when show_account_alias is false' do
+        check = CheckSubnetIpConsumption.new
+        expect(check.account_alias).to eq(nil)
+      end
+      it 'returns \'<no alias>\' when show_account_alias is true and there is no name' do
+        check = CheckSubnetIpConsumption.new
+        check.config[:show_account_alias] = true
+        expect(check.account_alias).to eq('<no alias>')
+      end
+    end
+  end
+
+  describe '#extract_name_tag' do
+    let(:tags_empty) { [] }
+    let(:tags_no_name) { [OpenStruct.new(key: 'Arbitrary', value: 'infinity')] }
+    let(:tags_with_name) { [OpenStruct.new(key: 'Name', value: 'my_name')] }
+    let(:tags_with_empty_name) { [OpenStruct.new(key: 'Name', value: '')] }
+
+    context 'with no tags' do
+      it 'returns <no name>' do
+        check = CheckSubnetIpConsumption.new
+        expect(check.extract_name_tag(tags_empty)).to eq('<no name>')
+      end
+    end
+    context 'with tags' do
+      context 'not including a Name tag' do
+        it 'returns <no name>' do
+          check = CheckSubnetIpConsumption.new
+          expect(check.extract_name_tag(tags_no_name)).to eq('<no name>')
+        end
+      end
+      context 'including an empty Name tag' do
+        it 'returns <no name>' do
+          check = CheckSubnetIpConsumption.new
+          expect(check.extract_name_tag(tags_with_empty_name)).to eq('<no name>')
+        end
+      end
+      context 'including a populated Name tag' do
+        it 'returns the name' do
+          check = CheckSubnetIpConsumption.new
+          expect(check.extract_name_tag(tags_with_name)).to eq('my_name')
+        end
+      end
+    end
+  end
+
+  describe '#display_subnet' do
+    context 'with defaults' do
+      it 'returns the subnet id' do
+        check = CheckSubnetIpConsumption.new
+        expect(check.display_subnet(test_alert)).to eq('subnet-00000000')
+      end
+    end
+    context 'with show_friendly_names enabled' do
+      it 'returns the subnet name' do
+        check = CheckSubnetIpConsumption.new
+        check.config[:show_friendly_names] = true
+        expect(check.display_subnet(test_alert)).to eq('subnet_name')
+      end
+      context 'with a <no name> subnet' do
+        it 'returns <no name>' do
+          check = CheckSubnetIpConsumption.new
+          check.config[:show_friendly_names] = true
+          expect(check.display_subnet(test_alert_with_no_names)).to eq('<no name>')
+        end
+      end
+    end
+  end
+
+  describe '#display_vpc' do
+    context 'with defaults' do
+      it 'returns the vpc id' do
+        check = CheckSubnetIpConsumption.new
+        expect(check.display_vpc(test_alert)).to eq('vpc-00000000')
+      end
+    end
+    context 'with show_friendly_names enabled' do
+      it 'returns the vpc name' do
+        check = CheckSubnetIpConsumption.new
+        check.config[:show_friendly_names] = true
+        expect(check.display_vpc(test_alert)).to eq('vpc_name')
+      end
+      context 'with a <no name> vpc' do
+        it 'returns <no name>' do
+          check = CheckSubnetIpConsumption.new
+          check.config[:show_friendly_names] = true
+          expect(check.display_vpc(test_alert_with_no_names)).to eq('<no name>')
+        end
+      end
+    end
+  end
+
+  describe '#run' do
+    context 'with an empty subnet' do
+      it 'should trigger ok with default threshold' do
+        check = CheckSubnetIpConsumption.new
+        response = check.run
+        expect(response).to match('triggered ok')
+      end
+      it 'should trigger critical when threshold is lowered to 0' do
+        check = CheckSubnetIpConsumption.new
+        check.config[:alert_threshold] = 0
+        response = check.run
+        expect(response).to match('triggered critical')
+      end
+    end
+    context 'with a full subnet' do
+      before :all do
+        @subnets = {
+          subnets: [
+            { subnet_id: 'subnet-test4567',
+              state: 'available',
+              cidr_block: '192.168.2.0/24',
+              vpc_id: 'vpc-12345678',
+              available_ip_address_count: 10,
+              availability_zone: 'us-east-1b',
+              tags: [{ key: 'Name', value: 'my_test_4567' }] }
+          ]
+        }
+        @vpcs = {
+          vpcs: [
+            { vpc_id: 'vpc-12345678',
+              state: 'available',
+              cidr_block: '192.168.1.0/20',
+              instance_tenancy: 'default',
+              is_default: true,
+              tags: [{ key: 'Name', value: 'my_vpc_12345678' }] }
+          ]
+        }
+
+        Aws.config[:iam] = { stub_responses: {
+          list_account_aliases: { account_aliases: ['my_account'] }
+        } }
+        Aws.config[:ec2] = { stub_responses: {
+          describe_subnets: @subnets,
+          describe_vpcs: @vpcs
+        } }
+      end
+      it 'should trigger critical with default threshold' do
+        check = CheckSubnetIpConsumption.new
+        response = check.run
+        expect(response).to match('triggered critical')
+      end
+      it 'should trigger ok when threshold is raised to 100' do
+        check = CheckSubnetIpConsumption.new
+        check.config[:alert_threshold] = 100
+        response = check.run
+        expect(response).to match('triggered ok')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No, this is adding new functionality

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)
- [x] Update README with any necessary configuration snippets
  - Not needed
- [x] Binstubs are created if needed
  - Not needed
- [x] RuboCop passes
- [x] Existing tests pass 
  - CheckKMSKey tests fail, which happens on a fresh clone

#### New Plugins

- [x] Tests
- [x] Add the plugin to the README
- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Allows you to set a threshold percentage, and will alert when the consumption of subnet IP addresses meets or exceeds that threshold. 

Examples:
- Using the default threshold of 85%,
  - Subnet-A is a /24 CIDR block, with 100 available addresses.
    - This means that 151 addresses have been consumed, or 60%. No alert is generated.
  - Subnet-B is a /23 CIDR block, with 30 available addresses.
    - This means that 477 addresses have been consumed, or 94%. An alert is generated.

#### Known Compatablity Issues
None. Requires 'OpenStruct' for tests, but this is built into Ruby 2.