### PR TITLE
Update check-beanstalk-health.rb to support optional region parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-sensu-clients.rb: SSL support
 - common.rb: adding support for environment variable AWS_REGION when region is specified as an empty string
 - metrics-sqs.rb: Add support for recording additional per-queue SQS metrics (counts of not-visible and delayed messages)
+- check-beanstalk-health.rb: Add optional region support
 
 ## [3.1.0] - 2016-05-15
 ### Fixed

--- a/bin/check-beanstalk-health.rb
+++ b/bin/check-beanstalk-health.rb
@@ -45,6 +45,11 @@ class BeanstalkHealth < Sensu::Plugin::Check::CLI
          boolean: true,
          default: true
 
+  option :aws_region,
+         short:       '-r AWS_REGION',
+         long:        '--aws-region REGION',
+         description: 'Optional parameter to specify AWS Region.'
+
   def env_health
     @env_health ||= beanstalk_client
                     .describe_environment_health(
@@ -54,7 +59,12 @@ class BeanstalkHealth < Sensu::Plugin::Check::CLI
   end
 
   def beanstalk_client
-    @beanstalk_client ||= Aws::ElasticBeanstalk::Client.new
+    if config[:aws_region]
+      @beanstalk_client ||= Aws::ElasticBeanstalk::Client.new(
+        region: config[:aws_region])
+    else
+      @beanstalk_client ||= Aws::ElasticBeanstalk::Client.new
+    end
   end
 
   def instances_health

--- a/bin/check-beanstalk-health.rb
+++ b/bin/check-beanstalk-health.rb
@@ -59,12 +59,13 @@ class BeanstalkHealth < Sensu::Plugin::Check::CLI
   end
 
   def beanstalk_client
-    if config[:aws_region]
-      @beanstalk_client ||= Aws::ElasticBeanstalk::Client.new(
-        region: config[:aws_region])
-    else
-      @beanstalk_client ||= Aws::ElasticBeanstalk::Client.new
-    end
+    @beanstalk_client ||= if config[:aws_region]
+                            Aws::ElasticBeanstalk::Client.new(
+                              region: config[:aws_region]
+                            )
+                          else
+                            Aws::ElasticBeanstalk::Client.new
+                          end
   end
 
   def instances_health


### PR DESCRIPTION
#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] RuboCop passes

- [X] Existing tests pass 

#### Purpose

Provide an optional region parameter to allow people using iam_role credentials to specify AWS_REGION.
