### PR TITLE
add support for assuming a role in a third party account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - syntax error in check-sensu-clients
 
 ### Added
+- check-rds.rb: Add support for assuming a role in another account
 - check-instance-events.rb: Add instance_id option
 - check-sensu-clients.rb: SSL support
 - common.rb: adding support for environment variable AWS_REGION when region is specified as an empty string


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

Added support for assuming a role in another account. This helps if there is a need to monitor rds instance on a third party account.



