### PR TITLE
this fixes updated events after remediation not working properly before

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- check-instance-health.rb: fixed remediated events not working after resolving it.
+
 
 ## [3.2.0] - 2016-08-03
 ### Fixed

--- a/bin/check-instance-health.rb
+++ b/bin/check-instance-health.rb
@@ -41,7 +41,7 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
          default: 'us-east-1'
 
   def gather_events(events)
-    useful_events = events.reject { |x| x[:code] == 'system-reboot' && x[:description] =~ /\[Completed\]/ }
+    useful_events = events.reject { |x| (x[:code] =~ /system-reboot|instance-stop|system-maintenance/) && (x[:description] =~ /\[Completed\]|\[Canceled\]/) }
     !useful_events.empty?
   end
 


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

Currently the check only resolve incidents if the code is only *system-reboot* and doesnt take care of other status like instance stopped or system maintenance cancelled e.g below event.

```
"Events": [
    {
        "Code": "instance-stop", 
        "Description": "[Completed] The instance is running on degraded hardware", 
        "NotBefore": "2016-08-22T23:00:00.000Z"
    }
]
```



