### PR TITLE
Add support for filters in check-instance-health

### DIFF
--- a/bin/check-instance-health.rb
+++ b/bin/check-instance-health.rb
@@ -39,6 +39,11 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
          long: '--aws-region REGION',
          description: 'AWS Region (defaults to us-east-1).',
          default: 'us-east-1'
+  option :filter,
+         short: '-f FILTER',
+         long: '--filter FILTER',
+         description: 'String representation of the filter to apply',
+         default: '{}'
 
   def gather_events(events)
     useful_events = events.reject { |x| (x[:code] =~ /system-reboot|instance-stop|system-maintenance/) && (x[:description] =~ /\[Completed\]|\[Canceled\]/) }
@@ -50,10 +55,28 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
   end
 
   def run
-    messages = []
+    filter = Filter.parse(config[:filter])
+    options = if filter.empty?
+                {}
+              else
+                { filters: filter }
+              end
+
+    messages = Array.new
+
     ec2 = Aws::EC2::Client.new
+    instance_ids = Array.new
+
+    instances = ec2.describe_instances(options)
+    instances.reservations.each do |r|
+      r.instances.each do |i|
+          instance_ids.push(i[:instance_id])
+      end
+    end
+
     begin
-      ec2.describe_instance_status.instance_statuses.each do |item|
+      resp = ec2.describe_instance_status({instance_ids: instance_ids})
+      resp.instance_statuses.each do |item|
         id = item.instance_id
         if gather_events(item.events)
           messages << "#{id} has unscheduled events"

--- a/bin/check-instance-health.rb
+++ b/bin/check-instance-health.rb
@@ -62,20 +62,20 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
                 { filters: filter }
               end
 
-    messages = Array.new
+    messages = []
 
     ec2 = Aws::EC2::Client.new
-    instance_ids = Array.new
+    instance_ids = []
 
     instances = ec2.describe_instances(options)
     instances.reservations.each do |r|
       r.instances.each do |i|
-          instance_ids.push(i[:instance_id])
+        instance_ids.push(i[:instance_id])
       end
     end
 
     begin
-      resp = ec2.describe_instance_status({instance_ids: instance_ids})
+      resp = ec2.describe_instance_status(instance_ids: instance_ids)
       resp.instance_statuses.each do |item|
         id = item.instance_id
         if gather_events(item.events)


### PR DESCRIPTION
This pull request adds support for regular AWS filters in check-instance-health  check.  As `describe_instance_status` doesn't support all filters [1], I've decided to implement filters using regular `describe_instances` call and then pass a list of instance IDs to `describe_instance_status`

[1] http://docs.aws.amazon.com/sdkforruby/api/Aws/EC2/Client.html#describe_instance_status-instance_method