### PR TITLE
move checks to sdk v2 and added some features to autoscaling instance count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,11 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-s3-object.rb: add an option to check s3 object's size
 
 ### Fixed
+- check-instance-events.rb: migrated the script to aws sdk v2 because of incompatibility of sdk v1 with newer regions (@oba11)
+- check-rds-events.rb: migrated the script to aws sdk v2 because of incompatibility of sdk v1 with newer regions (@oba11)
 - check-ses-limits.rb: Fix percentage calculation
 - check-rds.rb: Support added for checking all databases in a region
+- metrics-autoscaling-instance-count.rb: migrated the script to aws sdk v2 and support fetching all autoscaling groups (@oba11)
 
 ## [3.2.1] - 2016-08-10
 ### Fixed

--- a/bin/check-rds-events.rb
+++ b/bin/check-rds-events.rb
@@ -41,7 +41,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'aws-sdk-v1'
+require 'aws-sdk'
 
 class CheckRDSEvents < Sensu::Plugin::Check::CLI
   option :aws_access_key,
@@ -74,10 +74,7 @@ class CheckRDSEvents < Sensu::Plugin::Check::CLI
   end
 
   def rds_regions
-    # This is for SDK v2
-    # Aws.partition('aws').regions.map(&:name)
-
-    AWS::RDS.regions.map(&:name)
+    Aws.partition('aws').regions.map(&:name)
   end
 
   def run
@@ -102,7 +99,7 @@ class CheckRDSEvents < Sensu::Plugin::Check::CLI
     end
 
     aws_regions.each do |r|
-      rds = AWS::RDS::Client.new aws_config.merge!(region: r)
+      rds = Aws::RDS::Client.new aws_config.merge!(region: r)
 
       begin
         if !config[:db_instance_id].nil? && !config[:db_instance_id].empty?

--- a/bin/metrics-autoscaling-instance-count.rb
+++ b/bin/metrics-autoscaling-instance-count.rb
@@ -27,14 +27,14 @@
 #
 
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk-v1'
+require 'aws-sdk'
 
 class AutoScalingInstanceCountMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :groupname,
          description: 'Name of the AutoScaling group',
          short: '-g GROUP_NAME',
          long: '--autoscaling-group GROUP_NAME',
-         required: true
+         default: false
 
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',
@@ -60,22 +60,38 @@ class AutoScalingInstanceCountMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'AWS Region (defaults to us-east-1).',
          default: 'us-east-1'
 
+  option :include_name,
+         short: '-n',
+         long: '--include-name',
+         description: "Includes any offending instance's 'Name' tag in the metric output",
+         default: false
+
   def aws_config
     { access_key_id: config[:aws_access_key],
       secret_access_key: config[:aws_secret_access_key],
       region: config[:aws_region] }
   end
 
+  def autoscaling_groups
+    client = Aws::AutoScaling::Client.new(aws_config)
+    client.describe_auto_scaling_groups[:auto_scaling_groups].map(&:auto_scaling_group_name)
+  end
+
   def run
-    graphitepath = if config[:scheme] == ''
-                     "#{config[:groupname]}.autoscaling.instance_count"
-                   else
-                     config[:scheme]
-                   end
     begin
-      as = AWS::AutoScaling.new aws_config
-      count = as.groups[config[:groupname]].auto_scaling_instances.map(&:lifecycle_state).count('InService')
-      output graphitepath, count
+      groupnames ||= config[:groupname] ? [config[:groupname]] : autoscaling_groups
+      groupnames.each do |g|
+        as = Aws::AutoScaling::AutoScalingGroup.new aws_config.merge!(name: g)
+        count = as.instances.map(&:lifecycle_state).count('InService')
+        scheme_name ||= config[:include_name] ? as.data[:tags].select { |tag| tag[:key] == 'Name' }[0][:value] : g
+        graphitepath =
+          if config[:scheme] == ''
+            "#{scheme_name}.autoscaling.instance_count"
+          else
+            "#{config[:scheme]}.#{scheme_name}.instance_count"
+          end
+        output graphitepath, count
+      end
     rescue => e
       puts "Error: exception: #{e}"
       critical


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Yes, here => https://github.com/sensu-plugins/sensu-plugins-aws/issues/162

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [ ] Existing tests pass 

#### Purpose

* **check-instance-events.rb**: migrated the script to aws sdk v2 because of incompatibility of sdk v1 with newer regions
* **check-rds-events.rb**: migrated the script to aws sdk v2 because of incompatibility of sdk v1 with newer regions
* **metrics-autoscaling-instance-count.rb**: 
  * migrated the script to aws sdk v2
  * support fetching of all autoscaling groups in the sepcified region if no autoscaling name is specified
  * support usage of tag name as metric name (useful for beanstalk autoscaling groups with weird autoscaling names)

#### Known Compatablity Issues

None, didnot change existing check or metrics arguments so that it doesnt break compatability as long as aws-sdk gem is installed (should already been installed if sensu-plugins-aws gem is installed)