### PR TITLE
Add region support for check-cloudwatch-metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 ### Added
+- check-cloudwatch-alarm.rb: Add region support (@ptqa)
 - metrics-s3.rb: added
 - metrics-billing.rb: added
 - add check-cloudfront-tag.rb and check-s3-tag.rb (@obazoud)

--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -32,6 +32,12 @@ require 'sensu-plugin/check/cli'
 require 'aws-sdk'
 
 class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default: 'us-east-1'
+
   option :namespace,
          description: 'CloudWatch namespace for metric',
          short: '-n NAME',

--- a/lib/sensu-plugins-aws/cloudwatch-common.rb
+++ b/lib/sensu-plugins-aws/cloudwatch-common.rb
@@ -1,6 +1,8 @@
 require 'aws-sdk'
 
 module CloudwatchCommon
+  include Common
+
   def client
     Aws::CloudWatch::Client.new
   end


### PR DESCRIPTION
## Pull Request Checklist

No.

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Currently you have to set ENV variable in you check definition, but using CLI is better.

#### Known Compatablity Issues

It changes the way you specify region, so you have to change check definition. 
