### PR TITLE
Fix import for cloudwatch common

### DIFF
--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -27,7 +27,7 @@
 #   for details.
 #
 
-require 'sensu-plugins-aws/cloudwatch-common'
+require 'sensu-plugins-aws'
 require 'sensu-plugin/check/cli'
 require 'aws-sdk'
 

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -27,12 +27,10 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'sensu-plugins-aws/cloudwatch-common'
 require 'sensu-plugins-aws'
 require 'aws-sdk'
 
-class CheckEbsSnapshots < Sensu::Plugin::Check::CLI
-  include Common
+class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
   include CloudwatchCommon
 
   option :aws_region,

--- a/lib/sensu-plugins-aws.rb
+++ b/lib/sensu-plugins-aws.rb
@@ -1,3 +1,4 @@
 require 'sensu-plugins-aws/version'
 require 'sensu-plugins-aws/common'
 require 'sensu-plugins-aws/filter'
+require 'sensu-plugins-aws/cloudwatch-common'

--- a/lib/sensu-plugins-aws/cloudwatch-common.rb
+++ b/lib/sensu-plugins-aws/cloudwatch-common.rb
@@ -1,4 +1,3 @@
-require 'aws-sdk'
 
 module CloudwatchCommon
   include Common


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Nope

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass 

#### Purpose
This fixes the imports in the cloudwatch-common lib. Without this any check that uses it (check-cloudwatch-metric, check-ebs-burst-limit, etc) is broken:
```
aws_ebs_burst_limit: /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-aws-3.2.1/lib/sensu-plugins-aws/cloudwatch-common.rb:4:in `<module:CloudwatchCommon>': uninitialized constant CloudwatchCommon::Common (NameError)
    from /opt/sensu/embedded/lib/ruby/gems/2.3.0/gems/sensu-plugins-aws-3.2.1/lib/sensu-plugins-aws/cloudwatch-common.rb:3:in `<top (required)>'
    from /opt/sensu/embedded/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `require'
    from /opt/sensu/embedded/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:133:in `rescue in require'
    from /opt/sensu/embedded/lib/ruby/site_ruby/2.3.0/rubygems/core_ext/kernel_require.rb:40:in `require'
    from /opt/sensu/embedded/bin/check-ebs-burst-limit.rb:30:in `<main>'
:  : 
```


#### Known Compatablity Issues

None
