### PR TITLE
Add warning/critical flags to check-vpc-vpn.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - check-sqs-messages.rb added support for checking different metric types (@majormoses)
 - check-sqs-messages.rb upgraded to aws sdk v2 (@majormoses)
 - check-instances-count.rb fixed issues related to aws sdk version bump (@majormoses)
+- check-vpc-vpn.rb added warning/critical flags (@bootswithdefer)
 
 ### Fixed
 - check-instance-events.rb: migrated the script to aws sdk v2 because of incompatibility of sdk v1 with newer regions (@oba11)

--- a/bin/check-vpc-vpn.rb
+++ b/bin/check-vpc-vpn.rb
@@ -82,8 +82,8 @@ class CheckAwsVpcVpnConnections < Sensu::Plugin::Check::CLI
     msg = data[:down_connection_status].join(' | ')
     name = data[:connection_name]
     case data[:down_count]
-    when 2 then message="'#{name}' shows both tunnels as DOWN - [ #{msg} ]"
-    when 1 then message="'#{name}' shows 1 of 2 tunnels as DOWN - [ #{msg} ]"
+    when 2 then message = "'#{name}' shows both tunnels as DOWN - [ #{msg} ]"
+    when 1 then message = "'#{name}' shows 1 of 2 tunnels as DOWN - [ #{msg} ]"
     end
 
     if data[:down_count] >= config[:crit_count]


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Add warning/critical flags to check-vpc-vpn.rb so that situations where 1/2 tunnels being UP should be ok not warning.  Backwards compatibility is maintained, new flags are optional and default behavior is the same.

#### Known Compatablity Issues

