### PR TITLE
Pick most recent datapoint, not an arbitrary one

### DIFF
--- a/lib/sensu-plugins-aws/cloudwatch-common.rb
+++ b/lib/sensu-plugins-aws/cloudwatch-common.rb
@@ -7,7 +7,7 @@ module CloudwatchCommon
   end
 
   def read_value(resp, stats)
-    resp.datapoints.first.send(stats.downcase)
+    resp.datapoints.sort_by(&:timestamp).last.send(stats.downcase)
   end
 
   def resp_has_no_data(resp, stats)


### PR DESCRIPTION
Cloudwatch returns data points in an unspecified order, and choosing the
first one means you will get an arbitrary data point during the last 10
minutes (or 10 times whatever period you set). This sorts the values and
picks the most recent one as the value to compare against.

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [X] RuboCop passes

- [ ] Existing tests pass 

