### PR TITLE
Cloudwatch composite metric for percentage computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
-
-## [4.1.0]
 ###  Added
 - check-cloudwatch-composite-metric.rb: Allow calculation of percentage for cloudwatch metrics  by composing two metrics (numerator_metric/denominator_metric * 100) as a percentage. This is useful to skip pushing such metrics to graphite in order to get the percentage metric computed.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [4.1.0]
+###  Added
+- check-cloudwatch-composite-metric.rb: Allow calculation of percentage for cloudwatch metrics  by composing two metrics (numerator_metric/denominator_metric * 100) as a percentage. This is useful to skip pushing such metrics to graphite in order to get the percentage metric computed.
+
 ## [4.0.0] - 2016-12-27
 ### Breaking Changes
 - `check-sqs-messages.rb`, `check-vpc-vpn.rb`, and `metrics-elb.rb` were updated to aws-sdk v2 and no longer take `aws_access_key` and `aws_secret_access_key` options.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@
 
 **check-cloudwatch-alarm**
 
+**check-cloudwatch-metric
+
+**check-cloudwatch-composite-metric
+
 **check-cloudfront-tag**
 
 **check-configservice-rules**
@@ -153,6 +157,8 @@
 * /bin/check-configservice-rules.rb
 * /bin/check-cloudfront-tag.rb
 * /bin/check-cloudwatch-alarm.rb
+* /bin/check-cloudwatch-metric.rb
+* /bin/check-cloudwatch-composite-metric.rb
 * /bin/check-dynamodb-capacity.rb
 * /bin/check-dynamodb-throttle.rb
 * /bin/check-ebs-burst-limit.rb

--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 
 **check-cloudwatch-alarm**
 
-**check-cloudwatch-metric
+**check-cloudwatch-metric**
 
-**check-cloudwatch-composite-metric
+**check-cloudwatch-composite-metric**
 
 **check-cloudfront-tag**
 

--- a/bin/check-cloudwatch-composite-metric.rb
+++ b/bin/check-cloudwatch-composite-metric.rb
@@ -20,7 +20,7 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#   ./check-cloudwatch-composite-metric -m CPUUtilization -d InstanceId=i-12345678,AvailabilityZone=us-east-1a -c 90
+#   ./check-cloudwatch-composite-metric.rb --namespace AWS/ELB -N HTTPCode_Backend_4XX -D RequestCount --dimensions LoadBalancerName=test-elb --period 60 --statistics Maximum --operator equal --critical 0
 #
 # NOTES:
 #

--- a/bin/check-cloudwatch-composite-metric.rb
+++ b/bin/check-cloudwatch-composite-metric.rb
@@ -1,0 +1,132 @@
+#! /usr/bin/env ruby
+#
+# check-cloudwatch-composite-metric
+#
+# DESCRIPTION:
+#   This plugin retrieves a couple of values of two cloudwatch metrics,
+#   computes a percentage value based on the numerator metric and the denomicator metric
+#   and triggers alarms based on the thresholds specified.
+#   This plugin is an extension to the Andrew Matheny's check-cloudwatch-metric plugin
+#   and uses the CloudwatchCommon lib, extended as well.
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-cloudwatch-composite-metric -m CPUUtilization -d InstanceId=i-12345678,AvailabilityZone=us-east-1a -c 90
+#
+# NOTES:
+#
+# LICENSE:
+#   Cornel Foltea
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugins-aws'
+require 'sensu-plugin/check/cli'
+require 'aws-sdk'
+
+class CloudWatchCompositeMetricCheck < Sensu::Plugin::Check::CLI
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default: 'us-east-1'
+
+  option :namespace,
+         description: 'CloudWatch namespace for metric',
+         short: '-n NAME',
+         long: '--namespace NAME',
+         default: 'AWS/EC2'
+
+  option :numerator_metric_name,
+         description: 'Numerator metric name',
+         short: '-N NAME',
+         long: '--numerator-metric NAME',
+         required: true
+
+  option :denominator_metric_name,
+         description: 'Denominator metric name',
+         short: '-D NAME',
+         long: '--denominator-metric NAME',
+         required: true
+
+  option :dimensions,
+         description: 'Comma delimited list of DimName=Value',
+         short: '-d DIMENSIONS',
+         long: '--dimensions DIMENSIONS',
+         proc: proc { |d| CloudWatchCompositeMetricCheck.parse_dimensions d },
+         default: ''
+
+  option :period,
+         description: 'CloudWatch metric statistics period. Must be a multiple of 60',
+         short: '-p N',
+         long: '--period SECONDS',
+         default: 60,
+         proc: proc(&:to_i)
+
+  option :statistics,
+         short: '-s N',
+         long: '--statistics NAME',
+         default: 'Average',
+         description: 'CloudWatch statistics method'
+
+  option :unit,
+         short: '-u UNIT',
+         long: '--unit UNIT',
+         description: 'CloudWatch metric unit'
+
+  option :critical,
+         description: 'Trigger a critical when value is over VALUE',
+         short: '-c VALUE',
+         long: '--critical VALUE',
+         proc: proc(&:to_f),
+         required: true
+
+  option :warning,
+         description: 'Trigger a critical when value is over VALUE',
+         short: '-w VALUE',
+         long: '--warning VALUE',
+         proc: proc(&:to_f)
+
+  option :compare,
+         description: 'Comparision operator for threshold: equal, not, greater, less',
+         short: '-o OPERATION',
+         long: '--operator OPERATION',
+         default: 'greater'
+
+  option :no_data_ok,
+         short: '-O',
+         long: '--allow-no-data',
+         description: 'Returns ok if no data is returned from the metric',
+         boolean: true,
+         default: false
+
+  include CloudwatchCommon
+
+  def self.parse_dimensions(dimension_string)
+    dimension_string.split(',')
+                    .collect { |d| d.split '=' }
+                    .collect { |a| { name: a[0], value: a[1] } }
+  end
+
+  def dimension_string
+    config[:dimensions].map { |d| "#{d[:name]}=#{d[:value]}" }.join('&')
+  end
+
+  def metric_desc
+    "#{config[:namespace]}-#{config[:metric_name]}(#{dimension_string})"
+  end
+
+  def run
+    composite_check config
+  end
+end

--- a/lib/sensu-plugins-aws/cloudwatch-common.rb
+++ b/lib/sensu-plugins-aws/cloudwatch-common.rb
@@ -40,6 +40,44 @@ module CloudwatchCommon
     }
   end
 
+  def composite_metrics_request(config, metric, fixed_time_now = Time.now)
+    {
+      namespace: config[:namespace],
+      metric_name: config[metric],
+      dimensions: config[:dimensions],
+      start_time: fixed_time_now - config[:period] * 10,
+      end_time: fixed_time_now,
+      period: config[:period],
+      statistics: [config[:statistics]],
+      unit: config[:unit]
+    }
+  end
+
+  def composite_check(config)
+    fixed_time_now = Time.now
+    numerator_metric_resp = client.get_metric_statistics(composite_metrics_request(config, :numerator_metric_name, fixed_time_now))
+    denominator_metric_resp = client.get_metric_statistics(composite_metrics_request(config, :denominator_metric_name, fixed_time_now))
+
+    no_data = resp_has_no_data(numerator_metric_resp, config[:statistics]) || \
+              resp_has_no_data(denominator_metric_resp, config[:statistics])
+    if no_data && config[:no_data_ok]
+      ok "#{metric_desc} returned no data but that's ok"
+    elsif no_data && !config[:no_data_ok]
+      unknown "#{metric_desc} could not be retrieved"
+    end
+    value = (read_value(numerator_metric_resp, config[:statistics]).to_f / \
+             read_value(denominator_metric_resp, config[:statistics]).to_f * 100).to_i
+    base_msg = "#{metric_desc} is #{value}: comparison=#{config[:compare]}"
+
+    if compare value, config[:critical], config[:compare]
+      critical "#{base_msg} threshold=#{config[:critical]}"
+    elsif config[:warning] && compare(value, config[:warning], config[:compare])
+      warning "#{base_msg} threshold=#{config[:warning]}"
+    else
+      ok "#{base_msg}, will alarm at #{!config[:warning].nil? ? config[:warning] : config[:critical]}"
+    end
+  end
+
   def check(config)
     resp = client.get_metric_statistics(metrics_request(config))
 

--- a/lib/sensu-plugins-aws/version.rb
+++ b/lib/sensu-plugins-aws/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsAWS
   module Version
     MAJOR = 4
-    MINOR = 1
+    MINOR = 0
     PATCH = 0
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/sensu-plugins-aws/version.rb
+++ b/lib/sensu-plugins-aws/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsAWS
   module Version
     MAJOR = 4
-    MINOR = 0
+    MINOR = 1
     PATCH = 0
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### New Plugins

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Computes a percentage metric based on a couple of cloudwatch metrics, e.g. percentage of HTTPCode_Backend_4XX from the RequestCount over an observed period of time.

#### Known Compatablity Issues
None.
