### PR TITLE
adding support for specifying multiple queues for check-sqs-messages.rb without a prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ###  Added
 - check-cloudwatch-composite-metric.rb: Allow calculation of percentage for cloudwatch metrics  by composing two metrics (numerator_metric/denominator_metric * 100) as a percentage. This is useful to skip pushing such metrics to graphite in order to get the percentage metric computed.
+- check-sqs-messages.rb now supports specifying multiple queues wihtout a prefix
 
 ## [4.0.0] - 2016-12-27
 ### Breaking Changes


### PR DESCRIPTION
In some cases you can not use the prefix to check multiple queues with the same values (such as having a suffix to have it be identified as a dead letter queue). In these scenarios you might still want to be able to give it multiple queues to reduce the number of times you must invoke as initializing aws-sdk is expensive.

relates to:
- #24
- #27


#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 


#### Purpose
Support multiple queues per instance of check-sqs-messages.rb to reduce the resources required in scenarios where prefix is not a viable option.

#### Known Compatablity Issues

