### PR TITLE
fixes #80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 ## [Unreleased]
 ### Fixed
 - check-instance-health.rb now supports checking more than 100 instances (aws api limit) by batching into multiple requests if needed. (@majormoses)
+- check-elb-fog.rb set the variable name fog expects (@majormoses)
 
 ## [4.1.0] - 2017-05-01
 ###  Added

--- a/bin/check-elb-health-fog.rb
+++ b/bin/check-elb-health-fog.rb
@@ -81,8 +81,8 @@ class ELBHealth < Sensu::Plugin::Check::CLI
   end
 
   def aws_config
-    { access_key_id: config[:aws_access_key],
-      secret_access_key: config[:aws_secret_access_key],
+    { aws_access_key_id: config[:aws_access_key],
+      aws_secret_access_key: config[:aws_secret_access_key],
       region: config[:aws_region] }
   end
 


### PR DESCRIPTION
- fog expects aws_access_key_id and aws_secret_access_key and we were setting access_key_id and secret_access_key

## Pull Request Checklist

#80 

#### General

- [ ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass 

#### Purpose
Fix broken plugin (though.

#### Known Compatablity Issues
none
