### PR TITLE
check-elb-nodes returns unknown instead of critical if there are no nodes are backing it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## [5.0.1] - 2017-05-09
+## 2017-05-09
 ### Changed
 - check-elb-nodes.rb returns critical instead of unknown if total number of nodes equals zero
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
-## 2017-05-09
 ### Changed
 - check-elb-nodes.rb returns critical instead of unknown if total number of nodes equals zero
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+## [5.0.1] - 2017-05-09
+### Changed
+- check-elb-nodes.rb returns critical instead of unknown if total number of nodes equals zero
+
 ## [5.0.0] - 2017-05-03
 ### Breaking Change
 - removed check_vpc_vpn.py as it is broken and not worth fixing when `check-vpc-vpn.rb` is the direction forward. (@majormoses)

--- a/bin/check-elb-nodes.rb
+++ b/bin/check-elb-nodes.rb
@@ -125,7 +125,9 @@ class CheckELBNodes < Sensu::Plugin::Check::CLI
       message << " (#{state['Unknown'].join(', ')})"
     end
 
-    if state['Unknown'].count == num_instances
+    if num_instances.zero?
+      critical 'ELB has no nodes'
+    elsif state['Unknown'].count == num_instances
       unknown 'All nodes in unknown state'
     elsif state['InService'].count == 0
       critical message


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [X] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [X] Update README with any necessary configuration snippets

- [X] Binstubs are created if needed

- [ ] RuboCop passes
* No, but not due to my additions

- [X] Existing tests pass 

#### Purpose
If an Elastic Load Balancer has no more nodes attached to it, it reports an unknown state, since in line 128 (state['Unknown'].count == num_instances) both unknown and num_instances equal zero.
This should be a critical message, as is recongnized in the next check: state['InService'].count == 0. If there are no nodes backing my Load Balancer, it cannot perform its task and is therfore failed. That is definitively a critical problem that I would need to fix immediately, since my application is unavailable for that time.

#### Known Compatablity Issues

