### PR TITLE
support getting metrics for all queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+- metrics-sqs.rb: support fetching metrics for all sqs queues and migrated the script to aws sdk v2 (@oba11)
+
 ## [6.0.1] - 2017-05-11
 ### Fixed
 - check-instance-events.rb: fix instance Name tag retrieval that broke upon aws sdk v2 update, and update output message handling (@swibowo)


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Migrated the script to aws-sdk v2 and support fetching metrics for all sqs queues (initially only supports queue name & queue prefix)

#### Known Compatablity Issues

None, did not change existing metrics arguments (or metrics output) so that it doesnt break compatability as long as aws-sdk gem is installed (should already been installed if sensu-plugins-aws gem is installed)
