### PR TITLE
[check-ec2-filter] Add flag for specifying minimum runtime in seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ## [Unreleased]
 
+### Added
+
 - check-ec2-filter.rb: add --min-running-secs flag for specifying
   minimum number of seconds an instance should be running before it is
   included in the instance count.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+
+- check-ec2-filter.rb: add --min-running-secs flag for specifying
+  minimum number of seconds an instance should be running before it is
+  included in the instance count.
+
 ## [6.1.1] - 2017-07-07
 ### Added
 - ruby 2.4 testing (@majormoses)


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

In our use case I want to exclude instances from consideration until
they've been running for more than 2 hours. This change adds a
command line flag for specifying the minimum number of seconds an
instance should be running before it is included in the instance
count.

To my knowledge this kind of comparison isn't possible via the built-in filter.

#### Known Compatibility Issues

N/A