### PR TITLE
Add new check for monitoring ALB target group health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Add `check-alb-target-group-health.rb` that checks the health of ALB target groups (@eheydrick)
 
 ## [7.0.0] - 2017-08-07
 ### Breaking Change

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 ## Functionality
 
+**check-alb-target-group-health.rb**
+
 **check-asg-instances-created.rb**
 
 **check-asg-instances-inservice.rb**
@@ -151,6 +153,7 @@
 
 ## Files
 
+* /bin/check-alb-target-group-health.rb
 * /bin/check-asg-instances-created.rb
 * /bin/check-autoscaling-cpucredits.rb
 * /bin/check-asg-instances-inservice.rb

--- a/bin/check-alb-target-group-health.rb
+++ b/bin/check-alb-target-group-health.rb
@@ -1,0 +1,96 @@
+#!/usr/bin/env ruby
+#
+# check-alb-target-group-health
+#
+# DESCRIPTION:
+#   This plugin checks the health of Application Load Balancer target groups
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#   Check all target groups in a region
+#   check-alb-target-group-health.rb -r region
+#
+#   Check a single target group in a region
+#   check-alb-target-group-health.rb -r region -t target-group
+#
+#   Check multiple target groups in a region
+#   check-alb-target-group-health.rb -r region -t target-group-a,target-group-b
+#
+# LICENSE:
+#   Copyright 2017 Eric Heydrick <eheydrick@gmail.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+
+require 'aws-sdk'
+require 'sensu-plugin/check/cli'
+require 'sensu-plugins-aws'
+
+class CheckALBTargetGroupHealth < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :target_group,
+         short: '-t',
+         long: '--target-group TARGET_GROUP',
+         description: 'The ALB target group(s) to check. Separate multiple target groups with commas'
+
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default: 'us-east-1'
+
+  option :crit,
+         short: '-c',
+         long: '--crit',
+         description: 'Critical instead of warn when unhealthy targets are found',
+         boolean: true,
+         default: false
+
+  def alb
+    @alb ||= Aws::ElasticLoadBalancingV2::Client.new
+  end
+
+  def unhealthy_target_groups
+    unhealthy_groups = {}
+
+    target_groups_to_check = config[:target_group].split(',') if config[:target_group]
+    target_groups = alb.describe_target_groups(names: target_groups_to_check).target_groups
+
+    target_groups.each do |target_group|
+      health = alb.describe_target_health(target_group_arn: target_group.target_group_arn)
+      unhealthy_targets = health.target_health_descriptions.select { |t| t.target_health.state == 'unhealthy' }.map { |t| t.target.id }
+      unless unhealthy_targets.empty?
+        unhealthy_groups[target_group.target_group_name] = {
+          unhealthy_targets: unhealthy_targets,
+          total_targets: health.target_health_descriptions.size
+        }
+      end
+    end
+    unhealthy_groups
+  end
+
+  def run
+    unhealthy_groups = unhealthy_target_groups
+
+    if !unhealthy_groups.empty?
+      message = 'Unhealthy ALB target groups: '
+      message += unhealthy_groups.map { |target_group, value| "#{target_group} - #{value[:unhealthy_targets].size}/#{value[:total_targets]} unhealthy targets: {#{value[:unhealthy_targets].join(', ')}}" }.join(', ')
+      if config[:crit]
+        critical message
+      else
+        warning message
+      end
+    else
+      ok 'All ALB target groups are healthy'
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [x] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

New check for monitoring ALB target groups. Been running this for a while. Testing output:

Check all target groups in a region:
```
$ ./check-alb-target-group-health.rb -r us-west-2
CheckALBTargetGroupHealth WARNING: Unhealthy ALB target groups: example-service - 2/2 unhealthy targets: {i-00e31e3878b7ff800, i-08dfc79e79fa36f9c}
```

Check a single target group in a region:
```
$ ./check-alb-target-group-health.rb -r us-west-2 -t example-service
CheckALBTargetGroupHealth WARNING: Unhealthy ALB target groups: example-service - 2/2 unhealthy targets: {i-00e31e3878b7ff800, i-08dfc79e79fa36f9c}
```

Check multiple target groups in a region:
```
$ ./check-alb-target-group-health.rb -r us-west-2 -t example-service,another-service
CheckALBTargetGroupHealth WARNING: Unhealthy ALB target groups: another-service - 1/2 unhealthy targets: {i-049021d0efd2d5784}, example-service - 2/2 unhealthy targets: {i-00e31e3878b7ff800, i-08dfc79e79fa36f9c}
```

Output when all target groups are healthy:
```
$ ./check-alb-target-group-health.rb -r us-west-2
CheckALBTargetGroupHealth OK: All ALB target groups are healthy
```

#### Known Compatibility Issues

None