### PR TITLE
Fix typo: s/opertor/operator/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- check-beanstalk-elb-metric.rb and check-cloudwatch-metric.rb: `--opertor` flag was a typo, please use `--operator` now.
 
 ## [7.1.0] - 2017-08-14
 ### Added

--- a/bin/check-beanstalk-elb-metric.rb
+++ b/bin/check-beanstalk-elb-metric.rb
@@ -85,7 +85,7 @@ class BeanstalkELBCheck < Sensu::Plugin::Check::CLI
   option :compare,
          description: 'Comparision operator for threshold: equal, not, greater, less',
          short: '-o OPERATION',
-         long: '--opertor OPERATION',
+         long: '--operator OPERATION',
          default: 'greater'
 
   option :no_data_ok,

--- a/bin/check-cloudwatch-metric.rb
+++ b/bin/check-cloudwatch-metric.rb
@@ -91,7 +91,7 @@ class CloudWatchMetricCheck < Sensu::Plugin::Check::CLI
   option :compare,
          description: 'Comparision operator for threshold: equal, not, greater, less',
          short: '-o OPERATION',
-         long: '--opertor OPERATION',
+         long: '--operator OPERATION',
          default: 'greater'
 
   option :no_data_ok,


### PR DESCRIPTION
```
$ grep --recursive operator *                                                                                                                               
bin/check-ec2-filter.rb:#   Thresholds may be compared to the count using [equal, not, greater, less] operators.
bin/check-ec2-filter.rb:         description: 'Comparision operator for threshold: equal, not, greater, less',
bin/check-ec2-filter.rb:         long: '--operator OPERATION',
bin/check-ec2-filter.rb:  def convert_operator
bin/check-ec2-filter.rb:    op = convert_operator
bin/check-cloudwatch-composite-metric.rb:#   ./check-cloudwatch-composite-metric.rb --namespace AWS/ELB -N HTTPCode_Backend_4XX -D RequestCount --dimensions LoadBalancerName=test-elb --period 60 --statistics Maximum --operator equal --critical 0
bin/check-cloudwatch-composite-metric.rb:         description: 'Comparision operator for threshold: equal, not, greater, less',
bin/check-cloudwatch-composite-metric.rb:         long: '--operator OPERATION',
bin/check-beanstalk-elb-metric.rb:         description: 'Comparision operator for threshold: equal, not, greater, less',
bin/check-cloudwatch-metric.rb:         description: 'Comparision operator for threshold: equal, not, greater, less',
bin/check-s3-object.rb:         description: 'Comparision operator for threshold: equal, not, greater, less',
bin/check-s3-object.rb:         long: '--operator-size OPERATION',
bin/check-s3-object.rb:  def operator
bin/check-s3-object.rb:    send(level, msg % [element, value, config[:bucket_name]]) if operator.call type, value, to_check
```
Versus:

```
$ grep --recursive opertor *
bin/check-beanstalk-elb-metric.rb:         long: '--opertor OPERATION',
bin/check-cloudwatch-metric.rb:         long: '--opertor OPERATION',
```

Maybe this need to be documented in CHANGELOG.md ?