### PR TITLE
check-ebs-burst-limit.rb add -s option and fix -w option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Fixed
+check-ebs-burst-limit.rb: Only compare the warning threshold if a `-w` option was specified on the command-line, as usage shows `-w` is optional. (@ivanfetch)
+
 ### Added
-- check-ebs-burst-balance.rb: Only check volumes attached to the current instance with a new `-s` option, which also overrides the `-r` option for EC2 region. (@ivanfetch)
+- check-ebs-burst-limit.rb: Only check volumes attached to the current instance with a new `-s` option, which also overrides the `-r` option for EC2 region. (@ivanfetch)
 
 ## [8.0.0] - 2017-08-20
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-ebs-burst-balance.rb: Only check volumes attached to the current instance with a new `-s` option, which also overrides the `-r` option for EC2 region. (@ivanfetch)
 
 ## [8.0.0] - 2017-08-20
 ### Breaking Changes

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -33,7 +33,6 @@ require 'aws-sdk'
 require 'net/http'
 
 class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
-
   include CloudwatchCommon
 
   option :aws_region,
@@ -68,9 +67,9 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
     # Set the describe-volumes filter depending on whether -s was specified
     if config[:check_self] == true
       # Get the region from the availability zone, and override the -r option
-      my_instance_az  = Net::HTTP.get( URI.parse('http://169.254.169.254/latest/meta-data/placement/availability-zone'))
+      my_instance_az = Net::HTTP.get(URI.parse('http://169.254.169.254/latest/meta-data/placement/availability-zone'))
       Aws.config[:region] = my_instance_az.chop
-      my_instance_id = Net::HTTP.get( URI.parse('http://169.254.169.254/latest/meta-data/instance-id'))
+      my_instance_id = Net::HTTP.get(URI.parse('http://169.254.169.254/latest/meta-data/instance-id'))
       volume_filters = [
         {
           name: 'attachment.instance-id',
@@ -89,7 +88,7 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
 
     ec2 = Aws::EC2::Client.new
     volumes = ec2.describe_volumes(
-       filters: volume_filters
+      filters: volume_filters
     )
     config[:metric_name] = 'BurstBalance'
     config[:namespace] = 'AWS/EBS'

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -106,7 +106,7 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
         if resp.datapoints.first[:average] < config[:critical]
           errors << "#{volume[:volume_id]} #{resp.datapoints.first[:average]}"
           crit = true
-        elsif resp.datapoints.first[:average] < config[:warning]
+        elsif config[:warning] && resp.datapoints.first[:average] < config[:warning]
           errors << "#{volume[:volume_id]} #{resp.datapoints.first[:average]}"
           should_warn = true
         end

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -3,7 +3,8 @@
 # check-ebs-burst-limit
 #
 # DESCRIPTION:
-#   Check EC2 Attached Volumes for volumes with low burst balance
+#   Check EC2 Volumes for volumes with low burst balance
+#   Optionally check only volumes attached to the current instance
 #
 # OUTPUT:
 #   plain-text
@@ -29,14 +30,16 @@
 require 'sensu-plugin/check/cli'
 require 'sensu-plugins-aws'
 require 'aws-sdk'
+require 'net/http'
 
 class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
+
   include CloudwatchCommon
 
   option :aws_region,
          short:       '-r R',
          long:        '--region REGION',
-         description: 'AWS region',
+         description: 'AWS region, will be overridden by the -s option',
          default: 'us-east-1'
 
   option :critical,
@@ -52,16 +55,41 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
          long: '--warning VALUE',
          proc: proc(&:to_f)
 
+  option :check_self,
+         short: '-s',
+         long: '--check-self',
+         description: 'Only check the instance on which this plugin is being run - this overrides the -r option and uses the region of the current instance',
+         boolean: true,
+         default: false
+
   def run
     errors = []
-    ec2 = Aws::EC2::Client.new
-    volumes = ec2.describe_volumes(
-      filters: [
+
+    # Set the describe-volumes filter depending on whether -s was specified
+    if config[:check_self] == true
+      # Get the region from the availability zone, and override the -r option
+      my_instance_az  = Net::HTTP.get( URI.parse('http://169.254.169.254/latest/meta-data/placement/availability-zone'))
+      Aws.config[:region] = my_instance_az.chop
+      my_instance_id = Net::HTTP.get( URI.parse('http://169.254.169.254/latest/meta-data/instance-id'))
+      volume_filters = [
+        {
+          name: 'attachment.instance-id',
+          values: [my_instance_id]
+        }
+      ]
+    else
+      # The -s option was not specified, look at all volumes which are attached
+      volume_filters = [
         {
           name: 'attachment.status',
           values: ['attached']
         }
       ]
+    end
+
+    ec2 = Aws::EC2::Client.new
+    volumes = ec2.describe_volumes(
+       filters: volume_filters
     )
     config[:metric_name] = 'BurstBalance'
     config[:namespace] = 'AWS/EBS'


### PR DESCRIPTION
A new `-s` option is added to check-ebs-burst-limit.rb which limits the EBS volumes to those attached to the current EC2 instance, instead of checking all attached volumes. This also overrides the `-r` option, setting the region to that of the current EC2 instance.

The handling of the check-ebs-burst-limit.rb `-w` option is fixed so that the threshold is only compared to the metric if `-w` was specified on the command line.
