### PR TITLE
Add optional instance tag to message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-ec2-cpu_balance.rb: Add option `--tag`/`-t` to add a specified instace tag (e.g. instace name) to message. (@snadorp)
 
 ## [8.2.0] - 2017-09-05
 ### Added


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Didn't open one, so no.

#### Purpose
Adding more information about the machine having the problem to the warning/critial message. This is based on instance tags.
Old message:
`ruby bin/check-ec2-cpu_balance.rb -r eu-west-1 -c 10 -w 20`
```
EC2CpuBalance WARNING:
i-06d651[...]f508 is below warning threshold [18.42 < 20.0]
```
New message if tags are enabled:
`ruby bin/check-ec2-cpu_balance.rb -r eu-west-1 -c 10 -w 20 -t 'Name'`
```
EC2CpuBalance WARNING:
i-06d651[...]f508 (service01.live.company.com) is below warning threshold [18.42 < 20.0]
```

#### Known Compatibility Issues
None.