### PR TITLE
Update for AWS-SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Breaking Changes
+- metrics-sqs.rb: Update to AWS-SDK v2. With the update to SDK v2 this check no longer takes `aws_access_key` and `aws_secret_access_key` options.
+  Credentials should be set in environment variables, a credential file, or with an IAM instance profile.
+  See http://docs.aws.amazon.com/sdkforruby/api/#Configuration for details on setting credentials (@eheydrick)
 
 ## [8.3.0] - 2017-09-16
 ### Added

--- a/bin/metrics-sqs.rb
+++ b/bin/metrics-sqs.rb
@@ -12,12 +12,12 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk-v1
+#   gem: aws-sdk
 #   gem: sensu-plugin
 #
 # USAGE:
-#   metrics-sqs -q my_queue -a key -k secret
-#   metrics-sqs -p queue_prefix_ -a key -k secret
+#   metrics-sqs -q my_queue
+#   metrics-sqs -p queue_prefix_
 #
 # NOTES:
 #
@@ -28,9 +28,12 @@
 #
 
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk-v1'
+require 'sensu-plugins-aws'
+require 'aws-sdk'
 
 class SQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  include Common
+
   option :queue,
          description: 'Name of the queue',
          short: '-q QUEUE',
@@ -48,18 +51,6 @@ class SQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-s SCHEME',
          long: '--scheme SCHEME',
          default: ''
-
-  option :aws_access_key,
-         description: "AWS Access Key. Either set ENV['AWS_ACCESS_KEY'] or provide it as an option",
-         short: '-a AWS_ACCESS_KEY',
-         long: '--aws-access-key AWS_ACCESS_KEY',
-         default: ENV['AWS_ACCESS_KEY']
-
-  option :aws_secret_access_key,
-         description: "AWS Secret Access Key. Either set ENV['AWS_SECRET_ACCESS_KEY'] or provide it as an option",
-         short: '-k AWS_SECRET_KEY',
-         long: '--aws-secret-access-key AWS_SECRET_KEY',
-         default: ENV['AWS_SECRET_KEY']
 
   option :aws_region,
          description: 'AWS Region (defaults to us-east-1).',
@@ -79,24 +70,24 @@ class SQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def record_queue_metrics(q_name, q)
-    output scheme(q_name), q.approximate_number_of_messages
-    output "#{scheme(q_name)}.delayed", q.approximate_number_of_messages_delayed
-    output "#{scheme(q_name)}.not_visible", q.approximate_number_of_messages_not_visible
+    output scheme(q_name), q.attributes['ApproximateNumberOfMessages'].to_i
+    output "#{scheme(q_name)}.delayed", q.attributes['ApproximateNumberOfMessagesDelayed'].to_i
+    output "#{scheme(q_name)}.not_visible", q.attributes['ApproximateNumberOfMessagesNotVisible'].to_i
   end
 
   def run
     begin
-      sqs = AWS::SQS.new aws_config
+      sqs = Aws::SQS::Resource.new(aws_config)
 
       if config[:prefix] == ''
         if config[:queue] == ''
           critical 'Error, either QUEUE or PREFIX must be specified'
         end
 
-        record_queue_metrics(config[:queue], sqs.queues.named(config[:queue]))
+        record_queue_metrics(config[:queue], sqs.get_queue_by_name(queue_name: config[:queue]))
       else
-        sqs.queues.with_prefix(config[:prefix]).each do |q|
-          record_queue_metrics(q.arn.split(':').last, q)
+        sqs.queues(queue_name_prefix: config[:prefix]).each do |q|
+          record_queue_metrics(q.attributes['QueueArn'].split(':').last, q)
         end
       end
     rescue => e


### PR DESCRIPTION
## Pull Request Checklist

#240 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Update for AWS-SDK v2. This improves performance and reliability and gets us closer to being able to remove support for v1.

I verified that output is the same as under v1.

### Check a single queue:
```
$ ./metrics-sqs.rb -r us-west-2 -q cloudwatch-events
aws.sqs.queue.cloudwatch_events.message_count 0 1507616702
aws.sqs.queue.cloudwatch_events.message_count.delayed 0 1507616702
aws.sqs.queue.cloudwatch_events.message_count.not_visible 0 1507616702
```

### Check multiple queues by prefix:
```
$ ./metrics-sqs.rb -r us-west-2 -p dev
aws.sqs.queue.dev_somequeue.message_count 0 1507616832
aws.sqs.queue.dev_somequeue.message_count.delayed 0 1507616832
aws.sqs.queue.dev_somequeue.message_count.not_visible 0 1507616832
...
```

Performance is much improved when checking large numbers of queues. Under v1 checking 50 queues by prefix took 7.5s; under v2 it takes 2.5s

#### Known Compatibility Issues

This is a breaking change because it removes `aws_access_key` and `aws_secret_access_key` options per #2. 
