### PR TITLE
Update check-elb-certs for AWS-SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Breaking Changes
-- metrics-sqs.rb: Update to AWS-SDK v2. With the update to SDK v2 this check no longer takes `aws_access_key` and `aws_secret_access_key` options.
+- metrics-sqs.rb, check-elb-certs.rb: Update to AWS-SDK v2. With the update to SDK v2 this check no longer takes `aws_access_key` and `aws_secret_access_key` options.
   Credentials should be set in environment variables, a credential file, or with an IAM instance profile.
   See http://docs.aws.amazon.com/sdkforruby/api/#Configuration for details on setting credentials (@eheydrick)
 


### PR DESCRIPTION
Will likely need to rebase this once #241 is merged.

## Pull Request Checklist

#240 

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Update for AWS-SDK v2. This improves performance and reliability and gets us closer to being able to remove support for v1.

### OK state
```
$ ./check-elb-certs.rb -r us-west-2
CheckELBCerts OK: 4 ELB certs are valid for at least 30 days
```

### Warning state
```
$ ./check-elb-certs.rb -r us-west-2 -w 200
CheckELBCerts WARNING: 3 ELB certs are expiring within 200 days: something(198) anotherthing(198) fooelb(198)
```

#### Known Compatibility Issues

This is a breaking change because it removes `aws_access_key` and `aws_secret_access_key` options per #2. 