### PR TITLE
Update check-elb-nodes for AWS-SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Breaking Changes
-- metrics-sqs.rb, check-elb-certs.rb: Update to AWS-SDK v2. With the update to SDK v2 this check no longer takes `aws_access_key` and `aws_secret_access_key` options.
+- metrics-sqs.rb, check-elb-certs.rb, check-elb-nodes.rb, check-elb-health-sdk.rb: Update to AWS-SDK v2.
+  With the update to SDK v2 these checks no longer take `aws_access_key` and `aws_secret_access_key` options.
   Credentials should be set in environment variables, a credential file, or with an IAM instance profile.
   See http://docs.aws.amazon.com/sdkforruby/api/#Configuration for details on setting credentials (@eheydrick)
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#240 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Update for AWS-SDK v2. This improves performance and reliability and gets us closer to being able to remove support for v1.

OK state
```
$ ./check-elb-nodes.rb -n some-elb -r us-west-2
CheckELBNodes OK: InService: 2 (i-87a3d35a, i-a0c81534); OutOfService: 0; Unknown: 0
```

Warning state
```
$ ./check-elb-nodes.rb -n some-elb -r us-west-2 -w 1
CheckELBNodes WARNING: InService: 1 (i-87a3d35a); OutOfService: 1 (i-a0c81534); Unknown: 0
```

#### Known Compatibility Issues

This is a breaking change because it removes `aws_access_key` and `aws_secret_access_key` options per #2.