### PR TITLE
Update metrics-ec2-count for AWS-SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Breaking Changes
-- metrics-sqs.rb, check-elb-certs.rb, check-elb-nodes.rb, check-elb-health-sdk.rb: Update to AWS-SDK v2.
+- metrics-sqs.rb, check-elb-certs.rb, check-elb-nodes.rb, check-elb-health-sdk.rb, metrics-ec2-count.rb: Update to AWS-SDK v2.
   With the update to SDK v2 these checks no longer take `aws_access_key` and `aws_secret_access_key` options.
   Credentials should be set in environment variables, a credential file, or with an IAM instance profile.
   See http://docs.aws.amazon.com/sdkforruby/api/#Configuration for details on setting credentials (@eheydrick)


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#240 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Update for AWS-SDK v2. This improves performance and reliability and gets us closer to being able to remove support for v1.

Status of instances:
```
$ ./metrics-ec2-count.rb -r us-west-2 -t status
sensu.aws.ec2.count.total 4 1508134339
sensu.aws.ec2.count.running 3 1508134339
sensu.aws.ec2.count.stopped 1 1508134339
```

Instances by type:
```
$ ./metrics-ec2-count.rb -r us-west-2 -t instance
sensu.aws.ec2.types.t2.large 2 1508134391
sensu.aws.ec2.types.c4.large 1 1508134391
sensu.aws.ec2.types.t2.small 1 1508134391
...
```

#### Known Compatibility Issues

This is a breaking change because it removes `aws_access_key` and `aws_secret_access_key` options per #2.