### PR TITLE
metrics-billing.rb: replace -s with -S for services definition to prevent conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- metrics-billing.rb: replace `-s` with `-S` for services definition to prevent conflict with scheme option (@boutetnico)
 
 ## [9.0.0] - 2017-10-16
 ### Breaking Changes

--- a/bin/metrics-billing.rb
+++ b/bin/metrics-billing.rb
@@ -35,7 +35,7 @@ class BillingMetrics < Sensu::Plugin::Metric::CLI::Graphite
   include Common
 
   option :services_name,
-         short: '-s SERVICES_NAME',
+         short: '-S SERVICES_NAME',
          long: '--services-name SERVICES_NAME',
          description: 'The name of the AWS service (http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/billing-metricscollected.html)',
          default: 'AmazonEC2,AWSDataTransfer'


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

`metrics-billing.rb` has 2 different options that use the same `-s` short option. This PR changes that so that both short options can be used without any conflict. It works by adding `-S` for service definitions. Scheme definition remains `-s` as many other plugins.

#### Known Compatibility Issues
