### PR TITLE
Update handler-ses for AWS-SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Breaking Changes
+- handler-ses.rb: Update to AWS-SDK v2. With the update to AWS-SDK v2 this handler no longer takes `access_key`,  `secret_key`, or `use_ami_role` settings. Authentication should be configured per [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/README.md#authentication). (@eheydrick)
+
 ## [9.0.1] - 2017-10-17
 ### Fixed
 - metrics-billing.rb: replace `-s` with `-S` for services definition to prevent conflict with scheme option (@boutetnico)

--- a/README.md
+++ b/README.md
@@ -219,14 +219,25 @@
 ## Usage
 
 **handler-ses**
+
+1. Configure [authentication](#authentication)
+2. Enable the handler in `/etc/sensu/conf.d/handlers/ses.json`:
+```
+{
+  "handlers": {
+    "ses": {
+      "type": "pipe",
+      "command": "handler-ses.rb"
+    }
+  }
+}
+```
+3. Configure the handler in `/etc/sensu/conf.d/ses.json`:
 ```
 {
   "ses": {
     "mail_from": "sensu@example.com",
     "mail_to": "monitor@example.com",
-    "use_ami_role": true,
-    "access_key": "myaccesskey",
-    "secret_key": "mysecretkey",
     "region": "us-east-1",
     "subscriptions": {
       "subscription_name": {


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#240 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Update for AWS-SDK v2. This improves performance and reliability and gets us closer to being able to remove support for v1.

Sending mail works...
```
{"timestamp":"2017-10-20T07:15:40.662534+0000","level":"info","message":"handler output","handler":{"type":"pipe","command":"handler-ses.rb","name":"ses"},"output":["mail -- sent al
ert for somehost/check_printer to eric@somedomain.com\n"]}
```
<img width="466" alt="screen shot 2017-10-20 at 12 36 29 am" src="https://user-images.githubusercontent.com/328689/31809960-d037e0e0-b52e-11e7-8181-10c984103ff6.png">


#### Known Compatibility Issues

This is a breaking change because it removes `access_key`, `secret_key`, and `use_ami_role` options per #2 and to be consistent with how the other checks and handlers get credentials.