### PR TITLE
Update handler-sns for AWS-SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 
 ### Breaking Changes
-- handler-ses.rb: Update to AWS-SDK v2. With the update to AWS-SDK v2 this handler no longer takes `access_key`,  `secret_key`, or `use_ami_role` settings. Authentication should be configured per [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/README.md#authentication). (@eheydrick)
+- handler-ses.rb, handler-sns.rb: Update to AWS-SDK v2. With the update to AWS-SDK v2 these handlers no longer takes `access_key`,  `secret_key`, or `use_ami_role` settings. Authentication should be configured per [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/README.md#authentication). (@eheydrick)
 
 ## [9.0.1] - 2017-10-17
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ### Breaking Changes
 - handler-ses.rb, handler-sns.rb: Update to AWS-SDK v2. With the update to AWS-SDK v2 these handlers no longer takes `access_key`,  `secret_key`, or `use_ami_role` settings. Authentication should be configured per [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/README.md#authentication). (@eheydrick)
 
+### Changed
+- Update to `aws-sdk` 2.10 (@eheydrick)
+
 ## [9.0.1] - 2017-10-17
 ### Fixed
 - metrics-billing.rb: replace `-s` with `-S` for services definition to prevent conflict with scheme option (@boutetnico)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 ## [Unreleased]
 
 ### Breaking Changes
-- handler-ses.rb, handler-sns.rb: Update to AWS-SDK v2. With the update to AWS-SDK v2 these handlers no longer takes `access_key`,  `secret_key`, or `use_ami_role` settings. Authentication should be configured per [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/README.md#authentication). (@eheydrick)
+- handler-ses.rb, handler-sns.rb: Update to AWS-SDK v2. With the update to AWS-SDK v2 these handlers no longer take `access_key`, `secret_key`, or `use_ami_role` settings. Authentication should be configured per [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/README.md#authentication). (@eheydrick)
 
 ### Changed
 - Update to `aws-sdk` 2.10 (@eheydrick)

--- a/README.md
+++ b/README.md
@@ -249,13 +249,28 @@
 ```
 
 **handler-sns**
+
+`handler-sns` can be used to send alerts to Email, HTTP endpoints, SMS, or any other [subscription type](http://docs.aws.amazon.com/sns/latest/dg/welcome.html) supported by SNS.
+
+1. Create an SNS topic and subscription [[Docs]](http://docs.aws.amazon.com/sns/latest/dg/GettingStarted.html)
+1. Configure [authentication](#authentication)
+2. Enable the handler in `/etc/sensu/conf.d/handlers/sns.json`:
+```
+{
+  "handlers": {
+    "sns": {
+      "type": "pipe",
+      "command": "handler-sns.rb"
+    }
+  }
+}
+```
+3. Configure the handler in `/etc/sensu/conf.d/sns.json`:
 ```
 {
   "sns": {
     "topic_arn": "arn:aws:sns:us-east-1:111111111111:topic",
-    "use_ami_role": true,
-    "access_key": "MY_KEY",
-    "secret_key": "MY_secret"
+    "region": "us-east-1"
   }
 }
 ```

--- a/sensu-plugins-aws.gemspec
+++ b/sensu-plugins-aws.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsAWS::Version::VER_STRING
 
-  s.add_runtime_dependency 'aws-sdk',           '~> 2.3'
+  s.add_runtime_dependency 'aws-sdk',           '~> 2.10'
   s.add_runtime_dependency 'aws-sdk-v1',        '1.66.0'
   s.add_runtime_dependency 'fog',               '1.32.0'
   # 1.44 requires xmlrpc which only supports >= ruby 2.3


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
#240 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Update for AWS-SDK v2. This improves performance and reliability and gets us closer to being able to remove support for v1

Sending alerts to SMS via SNS works...

![screenshot_20171023-235725](https://user-images.githubusercontent.com/328689/31929300-5d60d78c-b850-11e7-9a72-b74961bc22b4.png)

#### Known Compatibility Issues

This is a breaking change because it removes `access_key`, `secret_key`, and `use_ami_role` options per #2 and to be consistent with how the other checks and handlers get credentials.