### PR TITLE
Add check-cloudwatch-alarm-multi.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- check-cloudwatch-alarm-multi.rb: Add check that will raise a critical if one of cloud watch alarms are in given state, and a critical for each alarm in given state. (@stevenayers)
 
 ## [11.0.0] - 2018-02-09
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@
 
 **check-cloudwatch-alarm**
 
+**check-cloudwatch-alarm-multi**
+
 **check-cloudwatch-alarms**
 
 **check-cloudwatch-composite-metric**
@@ -164,6 +166,8 @@
 * /bin/check-configservice-rules.rb
 * /bin/check-cloudfront-tag.rb
 * /bin/check-cloudwatch-alarm.rb
+* /bin/check-cloudwatch-alarm-multi.rb
+* /bin/check-cloudwatch-alarms.rb
 * /bin/check-cloudwatch-metric.rb
 * /bin/check-cloudwatch-composite-metric.rb
 * /bin/check-dynamodb-capacity.rb

--- a/bin/check-cloudwatch-alarm-multi.rb
+++ b/bin/check-cloudwatch-alarm-multi.rb
@@ -74,8 +74,7 @@ class CloudWatchCheck < Sensu::Plugin::Check::CLI
     end
 
     critical "#{alarms.size} in '#{config[:state]}' state: #{alarm_names.join(',')}" unless alarms.empty?
-
-  rescue => e
+  rescue StandardError => e
     puts "Error: exception: #{e}"
     critical
   end

--- a/bin/check-cloudwatch-alarm-multi.rb
+++ b/bin/check-cloudwatch-alarm-multi.rb
@@ -23,7 +23,7 @@
 # NOTES:
 #
 # LICENSE:
-#   Copyright (c) 2017, Steven Ayers, steveay99@gmail.com
+#   Copyright (c) 2017, Steven Ayers, sayers@equalexperts.com
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #

--- a/bin/check-cloudwatch-alarm-multi.rb
+++ b/bin/check-cloudwatch-alarm-multi.rb
@@ -1,0 +1,92 @@
+#! /usr/bin/env ruby
+#
+# check-cloudwatch-alarm-multi
+#
+# DESCRIPTION:
+#   This plugin raise a critical if one of cloud watch alarms are in given state, and a critical for
+#   each alarm in given state.
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-cloudwatch-alarm-multi --exclude-alarms "CPUAlarmLow"
+#   ./check-cloudwatch-alarm-multi --region eu-west-1 --exclude-alarms "CPUAlarmLow"
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright (c) 2017, Steven Ayers, steveay99@gmail.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'sensu-plugins-aws/common'
+require 'aws-sdk'
+
+class CloudWatchCheck < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default: 'us-east-1'
+
+  option :state,
+         description: 'State of the alarm',
+         short: '-s STATE',
+         long: '--state STATE',
+         default: 'ALARM'
+
+  option :exclude_alarms,
+         description: 'Exclude alarms',
+         short: '-e EXCLUDE_ALARMS',
+         long: '--exclude-alarms',
+         proc: proc { |a| a.split(',') },
+         default: []
+
+  def run
+    client = Aws::CloudWatch::Client.new
+    options = { state_value: config[:state] }
+    alarms = client.describe_alarms(options).metric_alarms
+
+    if alarms.empty?
+      ok "No alarms in '#{config[:state]}' state"
+    end
+
+    config[:exclude_alarms].each do |x|
+      alarms.delete_if { |alarm| alarm.alarm_name.match(x) }
+    end
+
+    alarm_names = alarms.map(&:alarm_name)
+
+    alarm_names.each do |alarm|
+      send_critical("check_cloudwatch_alarm_#{alarm}", "#{alarm} in '#{config[:state]}' state")
+    end
+
+    critical "#{alarms.size} in '#{config[:state]}' state: #{alarm_names.join(',')}" unless alarms.empty?
+
+  rescue => e
+    puts "Error: exception: #{e}"
+    critical
+  end
+
+  def sensu_client_socket(msg)
+    u = UDPSocket.new
+    u.send(msg + "\n", 0, '127.0.0.1', 3030)
+  end
+
+  def send_critical(check_name, msg)
+    d = { 'name' => check_name, 'status' => 2, 'output' => msg, 'handlers' => config[:handlers] }
+    sensu_client_socket d.to_json
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
No
#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [] Binstubs are created if needed

- [X] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [] Tests

- [X] Add the plugin to the README

- [X] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
We wanted a mixture of functionality from both check-cloudwatch-alarm & check-cloudwatch-alarms where you could query a dynamic list of cloudwatch alarms, however also have seperate critical checks for each one without defining seperate check definitions in JSON for each one.

#### Known Compatibility Issues
