### PR TITLE
Fix instance-health

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-instance-health.rb: fixed incorrect test operator from `&&` to `||` in `gather_events`, should reject if either case is true. (@randeffects)
 
 ## [10.1.0] - 2018-01-06
 - check-cloudwatch-composite-metric.rb: add flags `zero_denominator_data_ok`, `no_denominator_data_ok`, and `numerator_default` to add ability to allow numerator in composite to be 0. While leaving the functionality of `no_data_ok` the same, this change allows us to check to alert if the numerator has no data since 0/X is a valid alert case. (@zbintliff)

--- a/bin/check-instance-health.rb
+++ b/bin/check-instance-health.rb
@@ -46,7 +46,7 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
          default: '{}'
 
   def gather_events(events)
-    useful_events = events.reject { |x| (x[:code] =~ /system-reboot|instance-stop|system-maintenance/) && (x[:description] =~ /\[Completed\]|\[Canceled\]/) }
+    useful_events = events.reject { |x| (x[:code] =~ /system-reboot|instance-stop|system-maintenance/) || (x[:description] =~ /\[Completed\]|\[Canceled\]/) }
     !useful_events.empty?
   end
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Fixes ignoring "Completed" status of events that are manually remediated ahead of maintenance window. Changed comparison operator from AND (`&&`) to OR (`||`) in gather_events for `check-instance-health.rb`

#### Known Compatibility Issues

None
