### PR TITLE
Add region wide cluster monitoring.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Breaking changes
+- check-emr-cluster.rb: Monitor all clusters in one region or a single one, removed `warning_under` and `critical_under` parameter. (@snadorp)
 
 ## [10.1.0] - 2018-01-06
 - check-cloudwatch-composite-metric.rb: add flags `zero_denominator_data_ok`, `no_denominator_data_ok`, and `numerator_default` to add ability to allow numerator in composite to be 0. While leaving the functionality of `no_data_ok` the same, this change allows us to check to alert if the numerator has no data since 0/X is a valid alert case. (@zbintliff)


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
Nope.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
The current implementation of `check-emr-clusters` is only capable of monitoring one given cluster.
This new implementation is capable of monitoring all clusters in the given region and alert for all of them. It is still possible to monitor just one cluster by name.

#### Known Compatibility Issues
The configuration option for `warning_under` and `critical_under` have been removed.