### PR TITLE
improving s3 bucket visibility check for checking all buckets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Added
+- check-s3-bucket-visibility.rb: added option `--all-buckets` to check for all buckets in the region specified for insecure buckets (@majormoses)
+- check-s3-bucket-visibility.rb: added option `--excluded-buckets` to ignore specific buckets that are expected to be loose such as s3 buckets for static website hosting (@majormoses)
+
+### Changed
+- check-s3-bucket-visibility.rb: now uses `aws-sdk-s3` while keeping other plugins locked at their respective versions (@majormoses)
+
 ## [11.0.0] - 2018-02-09
 ### Breaking Changes
 - metrics-elb-full.rb: removed in favor of metrics-elb.rb, which is slightly more configurable and uses the AWS-SDK v2 already. Compared to metrics-elb-full.rb, metrics-elb.rb no longer takes --aws-access-key, --aws-secret-access-key flags, Authentication should be configured per [here](https://github.com/sensu-plugins/sensu-plugins-aws/blob/master/README.md#authentication). --scheme has a default value of `elb` now (@multani)

--- a/sensu-plugins-aws.gemspec
+++ b/sensu-plugins-aws.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
 
   s.add_runtime_dependency 'sensu-plugin',      '~> 2.0'
 
-  s.add_runtime_dependency 'aws-sdk',           '~> 2.10'
+  s.add_runtime_dependency 'aws-sdk',           '~> 3.0'
   s.add_runtime_dependency 'aws-sdk-v1',        '1.66.0'
   s.add_runtime_dependency 'erubis',            '2.7.0'
   s.add_runtime_dependency 'fog',               '1.32.0'

--- a/test/bin/check_s3_bucket_visibility_spec.rb
+++ b/test/bin/check_s3_bucket_visibility_spec.rb
@@ -71,7 +71,8 @@ describe 'CheckS3Bucket' do
   describe '#run' do
     it 'exits ok when restricted and no website policy' do
       check = CheckS3Bucket.new
-      check.config[:bucket_names] = 'my_bucket'
+      check.config[:bucket_names] = ['my_bucket']
+      check.config[:exclude_buckets] = ['some_other_bucket']
       @aws_stub.stub_responses(:get_bucket_website, 'NoSuchWebsiteConfiguration')
       @aws_stub.stub_responses(:get_bucket_policy, 'NoSuchBucketPolicy')
       allow(check).to receive(:s3_client).and_return(@aws_stub)
@@ -81,7 +82,8 @@ describe 'CheckS3Bucket' do
 
     it 'exits with critical when a website policy is detected' do
       check = CheckS3Bucket.new
-      check.config[:bucket_names] = 'my_bucket'
+      check.config[:bucket_names] = ['my_bucket']
+      check.config[:exclude_buckets] = ['some_other_bucket']
       @aws_stub.stub_responses(:get_bucket_website, @website_policy)
       @aws_stub.stub_responses(:get_bucket_policy, 'NoSuchBucketPolicy')
       allow(check).to receive(:s3_client).and_return(@aws_stub)
@@ -92,7 +94,8 @@ describe 'CheckS3Bucket' do
     it 'exits with critical when an overly permissive policy is detected' do
       skip "Can't mock StringIO in :get_bucket_policy"
       check = CheckS3Bucket.new
-      check.config[:bucket_names] = 'my_bucket'
+      check.config[:bucket_names] = ['my_bucket']
+      check.config[:exclude_buckets] = ['some_other_bucket']
       @aws_stub.stub_responses(:get_bucket_website, 'NoSuchWebsiteConfiguration')
       @aws_stub.stub_responses(:get_bucket_policy, policy: '{}')
       allow(check).to receive(:s3_client).and_return(@aws_stub)
@@ -102,7 +105,8 @@ describe 'CheckS3Bucket' do
 
     it 'exits with critical when one of two buckets fail' do
       check = CheckS3Bucket.new
-      check.config[:bucket_names] = 'safe_bucket,fail_bucket'
+      check.config[:bucket_names] = %w[safe_bucket fail_bucket]
+      check.config[:exclude_buckets] = ['some_other_bucket']
       @aws_stub.stub_responses(:get_bucket_website, ['NoSuchWebsiteConfiguration', @website_policy])
       allow(check).to receive(:s3_client).and_return(@aws_stub)
       response = check.run
@@ -111,7 +115,8 @@ describe 'CheckS3Bucket' do
 
     it 'exits with warning on a missing bucket' do
       check = CheckS3Bucket.new
-      check.config[:bucket_names] = 'missing_bucket'
+      check.config[:bucket_names] = ['missing_bucket']
+      check.config[:exclude_buckets] = ['some_other_bucket']
       check.config[:critical_on_missing] = 'false'
       @aws_stub.stub_responses(:get_bucket_website, 'NoSuchBucket')
       @aws_stub.stub_responses(:get_bucket_policy, 'NoSuchBucketPolicy')
@@ -122,7 +127,8 @@ describe 'CheckS3Bucket' do
 
     it 'exits with critical on a missing bucket when -m is specified' do
       check = CheckS3Bucket.new
-      check.config[:bucket_names] = 'missing_bucket'
+      check.config[:bucket_names] = ['missing_bucket']
+      check.config[:exclude_buckets] = ['some_other_bucket']
       check.config[:critical_on_missing] = 'true'
       @aws_stub.stub_responses(:get_bucket_website, 'NoSuchBucket')
       allow(check).to receive(:s3_client).and_return(@aws_stub)
@@ -132,7 +138,8 @@ describe 'CheckS3Bucket' do
 
     it 'exists with critical when one of several buckets is missing when -m is specified' do
       check = CheckS3Bucket.new
-      check.config[:bucket_names] = 'actual_bucket, missing_bucket'
+      check.config[:bucket_names] = %w[actual_bucket missing_bucket]
+      check.config[:exclude_buckets] = []
       check.config[:critical_on_missing] = 'true'
       @aws_stub.stub_responses(:get_bucket_website, %w[NoSuchWebsiteConfiguration NoSuchBucket])
       @aws_stub.stub_responses(:get_bucket_policy, %w[NoSuchBucketPolicy NoSuchBucket])


### PR DESCRIPTION
All the defaults remain the same and is backwards compatible

New options:
- `--all-buckets`: allows you to monitor all buckets in the specified region. Defaults to `false`
- `--excluded-buckets`: allows ignoring specific buckets that are expected to be more open for use cases such as static websites.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

~- [ ] Update README with any necessary configuration snippets~

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
Rather than maintaining a static list of all buckets you might want to look at all buckets in case someone creates a new bucket. This allows you to check per region all buckets. Also As you are now checking all buckets you need a way to ignore buckets where public access is intended such as static website hosting.

#### Known Compatibility Issues
none

#### Testing artifact

crit when a bucket is public:
```
$ bundle exec ./bin/check-s3-bucket-visibility.rb --aws-region us-west-2 --bucket-names NAMESPACE-terraform-backend,NAMESPACE-ENV2-cdn
CheckS3Bucket CRITICAL: NAMESPACE-ENV2-cdn: website configuration found; NAMESPACE-ENV2-cdn: bucket policy too permissive
```
one secure bucket and an excluded open bucket:
```
$ bundle exec ./bin/check-s3-bucket-visibility.rb --aws-region us-west-2 --bucket-names NAMESPACE-terraform-backend,NAMESPACE-ENV2-cdn --excluded-buckets NAMESPACE-ENV2-cdn
"bucket_name: NAMESPACE-ENV2-cdn was ignored as it matched excluded_buckets"
CheckS3Bucket OK: NAMESPACE-terraform-backend not exposed via website or bucket policy
```
testing all buckets, skipping buckets not in specified region, and working exclude:
```
$ bundle exec ./bin/check-s3-bucket-visibility.rb --aws-region us-west-2 --excluded-buckets NAMESPACE-ENV1-cdn,NAMESPACE-ENV1-fc --all-buckets true
"skipping bucket: NAMESPACE-cloud-trail as is not in the region specified: us-west-2"
"skipping bucket: NAMESPACE-cost-bucket as is not in the region specified: us-west-2"
"skipping bucket: ENV1-cost-bucket-east as is not in the region specified: us-west-2"
"bucket_name: NAMESPACE-ENV1-cdn was ignored as it matched excluded_buckets"
"bucket_name: NAMESPACE-ENV1-fc was ignored as it matched excluded_buckets"
CheckS3Bucket CRITICAL: NAMESPACE-ENV1-cdn: website configuration found; NAMESPACE-ENV1-cdn: bucket policy too permissive; NAMESPACE-ENV1-cdn-logs: bucket policy too permissive;
```

