### PR TITLE
Add option to allow filtering bucket names with regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Added
+- check-s3-bucket-visibility.rb: option `--exclude-regex-filter` to allow using regex to filter out undesired buckets from the results (@majormoses)
+
+### Fixed
+- check-s3-bucket-visibility.rb: fixed `nilClass` error when `--exlcuded-buckets` was not provided by returning false if its nil (@majormoses)
+
 ## [11.0.0] - 2018-11-21
 ### Added
 - check-s3-bucket-visibility.rb: added option `--all-buckets` to check for all buckets in the region specified for insecure buckets (@majormoses)


### PR DESCRIPTION
Fixed `nilClass` error when `--exclude-buckets` was not specified

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

#271 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

~- [ ] Binstubs are created if needed~

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Add regex filter option to make it easier to say all buckets but then filter down. Also fixed a bug introduced in #271 
#### Known Compatibility Issues
none

#### Testing Artifacts

Before:
```
$ bundle exec ./bin/check-s3-bucket-visibility.rb --aws-region us-west-2 -all --exclude-regex-filter dev-
"skipping bucket: $REDACTED-1 as is not in the region specified: us-west-2"
"skipping bucket: $REDACTED-2 as is not in the region specified: us-west-2"
"skipping bucket: $REDACTED-3 as is not in the region specified: us-west-2"
Check failed to run: undefined method `include?' for nil:NilClass, ["./bin/check-s3-bucket-visibility.rb:99:in `excluded_bucket?'", "./bin/check-s3-bucket-visibility.rb:147:in `block in run'", "./bin/check-s3-bucket-visibility.rb:146:in `each'", "./bin/check-s3-bucket-visibility.rb:146:in `run'", "/home/babrams/.rbenv/versions/2.3.5/lib/ruby/gems/2.3.0/gems/sensu-plugin-2.4.0/lib/sensu-plugin/cli.rb:57:in `block in <class:CLI>'"]
```
After:
```
$ bundle exec ./bin/check-s3-bucket-visibility.rb --aws-region us-west-2 -all --exclude-regex-filter dev-
"skipping bucket: $REDACTED-1 as is not in the region specified: us-west-2"
"skipping bucket: $REDACTED-2 as is not in the region specified: us-west-2"
"skipping bucket: $REDACTED-3 as is not in the region specified: us-west-2"
"bucket_name: $REDACTED-dev-4 was ignored as it matched exclude_regex_filter: (?-mix:dev\\-)"
"bucket_name: $REDACTED-dev-5 was ignored as it matched exclude_regex_filter: (?-mix:dev\\-)"
<TRUNCATED_OUTPUT>
CheckS3Bucket CRITICAL: $REDACTED-6: website configuration found; $REDACTED-6: bucket policy too permissive; 
```
