### PR TITLE
Trim all leading spaces from SES email bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- Trim all leading whitespace from each line in the email bodies when using the SES handler, and not a specific number of spaces, which may change as files are reformatted/refactored. (@mattdoller)
 
 ## [11.4.0] - 2018-04-28
 ### Security

--- a/bin/handler-ses.rb
+++ b/bin/handler-ses.rb
@@ -58,7 +58,7 @@ class SESNotifier < Sensu::Handler
 
   def handle
     mail_to = build_mail_to_list
-    body = <<-BODY.gsub(/^ {14}/, '')
+    body = <<-BODY.gsub(/^\s+/, '')
             #{@event['check']['output']}
             Host: #{@event['client']['name']}
             Timestamp: #{Time.at(@event['check']['issued'])}


### PR DESCRIPTION
The heredoc was looking for a specific amount of whitespace to trim,
but the indentation may have changed and the number of spaces
specified to trim is no longer valid.  Just trim all leading
whitespace from each line in the email body in the SES hander.

## Pull Request Checklist

**Is this in reference to an existing issue?**

no

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Fix alignment of Sensu notification emails sent using the SES handler.

#### Known Compatibility Issues

none
