### PR TITLE
Handles case where --key-prefix is used and no objects are found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- Handle case where a prefix is used and no objects are found. (@akatch)
 
 ## [11.4.1] - 2018-05-07
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Fixed
 - Handle case where a prefix is used and no objects are found. (@akatch)
 
 ## [11.4.1] - 2018-05-07

--- a/bin/check-s3-object.rb
+++ b/bin/check-s3-object.rb
@@ -158,12 +158,16 @@ class CheckS3Object < Sensu::Plugin::Check::CLI
       elsif !config[:key_prefix].nil?
         key_search = config[:key_prefix]
         output = s3.list_objects(bucket: config[:bucket_name], prefix: key_search)
-        key_fullname = output.contents[0].key
+
+        if output.contents.size.to_i < 1
+          critical "Object with prefix \"#{key_search}\" not found in bucket #{config[:bucket_name]}"
+        end
 
         if output.contents.size.to_i > 1
           critical "Your prefix \"#{key_search}\" return too much files, you need to be more specific"
         end
 
+        key_fullname = output.contents[0].key
         age = Time.now.to_i - output.contents[0].last_modified.to_i
         size = output.contents[0].size
       end


### PR DESCRIPTION
Previously this would throw "undefined method 'key'" if a prefix is
provided and no objects are found.

## Pull Request Checklist

This is not in reference to an existing issue.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose
bug fixin'

#### Known Compatibility Issues
None at this time