### PR TITLE
Run check against most recent s3 object in list of matching objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+## [12.2.0] - 2018-09-14
+### Added
 - Add `check-direct-connect-virtual-interfaces.rb` to check the status of Direct Connect virtual interfaces
 
 ## [12.1.0] - 2018-08-28
@@ -495,7 +498,8 @@ WARNING:  This release contains major breaking changes that will impact all user
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.1.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.2.0...HEAD
+[12.2.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.1.0...12.2.0
 [12.1.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.0.0...12.1.0
 [12.0.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.6.0...12.0.0
 [11.6.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.1...11.6.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+## [11.6.0] - 2018-06-21
+### Added
 - metrics-rds.rb: adding option `--fetch-age` to allow getting metrics in the past (@multani)
 
 ## [11.5.1] - 2018-06-21
@@ -483,7 +486,8 @@ WARNING:  This release contains major breaking changes that will impact all user
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.1...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.6.0...HEAD
+[11.6.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.1...11.6.0
 [11.5.1]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.0...11.5.1
 [11.5.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.4.2...11.5.0
 [11.4.2]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.4.1...11.4.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- Add `check-direct-connect-virtual-interfaces.rb` to check the status of Direct Connect virtual interfaces
 
 ## [12.1.0] - 2018-08-28
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- check-s3-objects.rb: Allow check to run against the newest of multiple matching objects (@akatch)
 
 ## [12.2.0] - 2018-09-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- `check-ebs-burst-limit.rb`: Fixed period to pass to config from 60 to 120 so as to not have empty values returned sometimes
 
 ## [11.6.0] - 2018-06-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
-- `check-ebs-burst-limit.rb`: Fixed period to pass to config from 60 to 120 so as to not have empty values returned sometimes
+
+## [12.0.0] - 2018-06-21
+### Breaking Changes
+- `check-ebs-burst-limit.rb`: Fixed period to pass to config from 60 to 120 so as to not have empty values returned sometimes (@wari)
 
 ## [11.6.0] - 2018-06-21
 ### Added
@@ -487,7 +490,8 @@ WARNING:  This release contains major breaking changes that will impact all user
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.6.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.0.0...HEAD
+[12.0.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.6.0...12.0.0
 [11.6.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.1...11.6.0
 [11.5.1]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.0...11.5.1
 [11.5.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.4.2...11.5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Added
+- new `check-efs.rb: checks cloudwatch metrics with the efs namespace for an arbitrary metric (@ivanfetch)
+
 ## [12.0.0] - 2018-06-21
 ### Breaking Changes
 - `check-ebs-burst-limit.rb`: Fixed period to pass to config from 60 to 120 so as to not have empty values returned sometimes (@wari)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-rds-pending: Fix issue if there are no RDS instances in a region. Previously this would raise an API exception (@stevenviola)
 
 ## [11.5.0] - 2018-05-17
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+## [12.1.0] - 2018-08-28
 ### Added
 - new `check-efs.rb: checks cloudwatch metrics with the efs namespace for an arbitrary metric (@ivanfetch)
 
@@ -493,7 +494,8 @@ WARNING:  This release contains major breaking changes that will impact all user
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.0.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.1.0...HEAD
+[12.1.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/12.0.0...12.1.0
 [12.0.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.6.0...12.0.0
 [11.6.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.1...11.6.0
 [11.5.1]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.0...11.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+## [11.5.1] - 2018-06-21
 ### Fixed
 - check-rds-pending: Fix issue if there are no RDS instances in a region. Previously this would raise an API exception (@stevenviola)
 
@@ -480,7 +482,8 @@ WARNING:  This release contains major breaking changes that will impact all user
 ### Added
 - initial release
 
-[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.0...HEAD
+[Unreleased]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.1...HEAD
+[11.5.1]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.5.0...11.5.1
 [11.5.0]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.4.2...11.5.0
 [11.4.2]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.4.1...11.4.2
 [11.4.1]: https://github.com/sensu-plugins/sensu-plugins-aws/compare/11.4.0...11.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- metrics-rds.rb: adding option `--fetch-age` to allow getting metrics in the past (@multani)
 
 ## [11.5.1] - 2018-06-21
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@
 
 **check-ecs-service-health.rb**
 
+**check-efs-metric.rb**
+
 **check-eip-allocation.rb**
 
 **check-elasticache-failover.rb**
@@ -173,6 +175,7 @@
 * /bin/check-ec2-filter.rb
 * /bin/check-ec2-network.rb
 * /bin/check-ecs-service-health.rb
+* /bin/check-efs-metric.rb
 * /bin/check-elasticache-failover.rb
 * /bin/check-elb-certs.rb
 * /bin/check-elb-health-fog.rb

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@
 
 **check-dynamodb-throttle.rb**
 
+**check-direct-connect-virtual-interfaces.rb**
+
 **check-ebs-snapshots.rb**
 
 **check-ebs-burst-limit.rb**
@@ -170,6 +172,7 @@
 * /bin/check-cloudwatch-composite-metric.rb
 * /bin/check-dynamodb-capacity.rb
 * /bin/check-dynamodb-throttle.rb
+* /bin/check-direct-connect-virtual-interfaces.rb
 * /bin/check-ebs-burst-limit.rb
 * /bin/check-ebs-snapshots.rb
 * /bin/check-ec2-filter.rb

--- a/bin/check-direct-connect-virtual-interfaces.rb
+++ b/bin/check-direct-connect-virtual-interfaces.rb
@@ -1,0 +1,84 @@
+#! /usr/bin/env ruby
+#
+# check-direct-connect-virtual-interfaces
+#
+# DESCRIPTION:
+#   This plugin uses the AWS Direct Connect API to check the status
+#   of virtual interfaces
+#
+#   CRIT: one or more interfaces status not 'available' (down)
+#   WARN: no virtual interfaces detected
+#   OK:   all interfaces checked available
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux, Windows, Mac
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#  ./check-direct-connect.rb -r {us-east-1|eu-west-1} [-c all]
+#
+# NOTES:
+#
+# LICENSE:
+#   Guillaume Delacour <guillaume.delacour@fr.clara.net>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+
+require 'sensu-plugin/check/cli'
+require 'sensu-plugins-aws'
+require 'aws-sdk'
+
+class CheckDcVirtualInterfacesHealth < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region AWS_REGION',
+         description: 'The AWS region in which to check rules. Currently only available in us-east-1.',
+         default: 'us-east-1'
+
+  option :connection_id,
+         short: '-c CONNECTION_ID',
+         long: '--connection-id CONNECTION_ID',
+         description: 'The connection id to check. Default is to check all connection ids',
+         default: 'all'
+
+  def dc_client
+    @dc_client ||= Aws::DirectConnect::Client.new
+  end
+
+  def virtual_interfaces_details(connection_id = 'all')
+    if connection_id == 'all'
+      dc_client.describe_virtual_interfaces
+    else
+      dc_client.describe_virtual_interfaces(connection_id: connection_id)
+    end
+  end
+
+  def run
+    virtual_interfaces_healths = virtual_interfaces_details(config[:connection_id])
+    if virtual_interfaces_healths[0].length.zero?
+      warning('No virtual interfaces to check')
+    end
+
+    unhealthy = []
+
+    virtual_interfaces_healths[0].each do |virtual_interface|
+      unhealthy.push(virtual_interface.virtual_interface_name) if virtual_interface.virtual_interface_state != 'available'
+    end
+
+    if !unhealthy.length.zero?
+      critical("Not 'available' virtual interfaces: #{unhealthy.join ', '}")
+    else
+      ok(config[:connection_id].to_s)
+    end
+  rescue StandardError => e
+    unknown "An error occurred processing AWS DirectConnect API: #{e.message}"
+  end
+end

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -93,7 +93,7 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
     config[:metric_name] = 'BurstBalance'
     config[:namespace] = 'AWS/EBS'
     config[:statistics] = 'Average'
-    config[:period] = 60
+    config[:period] = 120
     crit = false
     should_warn = false
 

--- a/bin/check-efs-metric.rb
+++ b/bin/check-efs-metric.rb
@@ -1,0 +1,145 @@
+#!/usr/bin/env ruby
+#
+# check-efs-metric
+#
+# DESCRIPTION:
+#   This plugin checks a CloudWatch metric from the AWS/EFS namespace
+#   For more details, see https://docs.aws.amazon.com/efs/latest/ug/monitoring-cloudwatch.html#efs-metrics
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#   ./check-efs-metric -w 25.0 -c 75.0 \
+#   -m PercentIOLimit -o greater -n my-efs-filesystem-name
+#
+# NOTES:
+#
+# LICENSE:
+#   Ivan Fetch
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugins-aws'
+require 'sensu-plugin/check/cli'
+require 'aws-sdk'
+
+# A Sensu plugin which uses cloudwatch-common to  check EFS CloudWatch metrics
+class EFSMetric < Sensu::Plugin::Check::CLI
+  include Common
+  include CloudwatchCommon
+
+  option :efs_name,
+         description: 'Name of the EFS file system, matching the Name tag',
+         short: '-n VALUE',
+         long: '--name VALUE',
+         proc: proc(&:to_s),
+         required: true
+
+  option :metric_name,
+         description: 'CloudWatch metric in the AWS/EFS namespace: E.G. PercentIOLimit',
+         short: '-m VALUE',
+         long: '--metric VALUE',
+         proc: proc(&:to_s),
+         required: true
+
+  option :statistics,
+         description: 'Statistic to retrieve from CloudWatch: E.G. Minimum or Maximum',
+         short: '-s statistic',
+         long: '--statistic statistic',
+         default: 'Average',
+         proc: proc(&:to_s)
+
+  option :critical,
+         description: 'Return critical when the metric is at this VALUE, also see the --operator option',
+         short: '-c VALUE',
+         long: '--critical VALUE',
+         proc: proc(&:to_f),
+         required: true
+
+  option :warning,
+         description: 'Return warning when the metric is at this VALUE, also see the --operator option',
+         short: '-w VALUE',
+         long: '--warning VALUE',
+         proc: proc(&:to_f)
+
+  option :period,
+         description: 'CloudWatch metric statistics period, in seconds. Must be a multiple   of 60',
+         short: '-p VALUE',
+         long: '--period VALUE',
+         default: 60,
+         proc: proc(&:to_i)
+
+  option :compare,
+         description: 'Comparison operator for critical and warning thresholds: equal, not, greater, less',
+         short: '-o OPERATOR',
+         long: '--operator OPERATOR',
+         default: 'less'
+
+  option :unit,
+         description: 'CloudWatch metric unit, to be passed to the metrics request',
+         short: '-u UNIT',
+         long: '--unit UNIT'
+
+  option :no_data_ok,
+         description: 'Returns ok if no data is returned from the metric',
+         short: '-O',
+         long: '--allow-no-data',
+         boolean: true,
+         default: false
+
+  option :no_efs_ok,
+         description: 'Returns ok if the EFS file system specified by the -n option can not be found: This is useful if using a check in multiple environments where a file system may not always exist',
+         short: '-N',
+         long: '--allow-no-efs',
+         boolean: true,
+         default: false
+
+  option :aws_region,
+         description: 'AWS region',
+         short: '-r Region',
+         long: '--region REGION',
+         default: 'us-east-1'
+
+  # This is used by CloudwatchCommon to display the description for what is being checked.
+  def metric_desc
+    "#{config[:metric_name]} for #{config[:efs_name]}"
+  end
+
+  def run
+    config[:namespace] = 'AWS/EFS'
+    found_efs = false
+
+    efs = Aws::EFS::Client.new
+    filesystems = efs.describe_file_systems
+    filesystems.file_systems.each do |filesystem|
+      # Once Ruby < ver 2.4 is not supported, change this to:
+      # if filesystem.name.casecmp?(config[:efs_name])
+      # See : https://ruby-doc.org/core-2.4.0/String.html#method-i-casecmp
+      if filesystem.name.casecmp(config[:efs_name]).zero?
+        found_efs = true
+        config[:dimensions] = []
+        config[:dimensions] << { name: 'FileSystemId', value: filesystem.file_system_id }
+        check config
+      end
+    end
+
+    # rubocop:disable Style/GuardClause
+    unless found_efs
+      if config[:no_efs_ok]
+        ok "EFS file system #{config[:efs_name]} was not found in region #{config[:aws_region]} but that's ok"
+      else
+        critical "EFS file system #{config[:efs_name]} was not found in region #{config[:aws_region]}"
+      end
+    end
+    # rubocop:enable Style/GuardClause
+  end
+end

--- a/bin/check-rds-pending.rb
+++ b/bin/check-rds-pending.rb
@@ -47,10 +47,12 @@ class CheckRDSEvents < Sensu::Plugin::Check::CLI
       # fetch all clusters identifiers
       clusters = rds.describe_db_instances[:db_instances].map { |db| db[:db_instance_identifier] }
       maint_clusters = []
-      # Check if there is any pending maintenance required
-      pending_record = rds.describe_pending_maintenance_actions(filters: [{ name: 'db-instance-id', values: clusters }])
-      pending_record[:pending_maintenance_actions].each do |response|
-        maint_clusters.push(response[:pending_maintenance_action_details])
+      if clusters.any?
+        # Check if there is any pending maintenance required
+        pending_record = rds.describe_pending_maintenance_actions(filters: [{ name: 'db-instance-id', values: clusters }])
+        pending_record[:pending_maintenance_actions].each do |response|
+          maint_clusters.push(response[:pending_maintenance_action_details])
+        end
       end
     rescue StandardError => e
       unknown "An error occurred processing AWS RDS API: #{e.message}"

--- a/bin/check-s3-object.rb
+++ b/bin/check-s3-object.rb
@@ -164,6 +164,7 @@ class CheckS3Object < Sensu::Plugin::Check::CLI
       elsif !config[:key_prefix].nil?
         key_search = config[:key_prefix]
         output = s3.list_objects(bucket: config[:bucket_name], prefix: key_search)
+        output = output.next_page while output.next_page?
 
         if output.contents.size.to_i < 1
           critical "Object with prefix \"#{key_search}\" not found in bucket #{config[:bucket_name]}"

--- a/bin/check-s3-object.rb
+++ b/bin/check-s3-object.rb
@@ -105,7 +105,7 @@ class CheckS3Object < Sensu::Plugin::Check::CLI
   option :no_crit_on_multiple_objects,
          description: 'If this flag is set, sort all matching objects by last_modified date and check against the newest. By default, this check will return a CRITICAL result if multiple matching objects are found.',
          short: '-m',
-         long: '--no-crit-on-multiple-objects',
+         long: '--ok-on-multiple-objects',
          boolean: true
 
   def aws_config

--- a/bin/metrics-rds.rb
+++ b/bin/metrics-rds.rb
@@ -57,6 +57,13 @@ class RDSMetrics < Sensu::Plugin::Metric::CLI::Graphite
          proc:        proc { |a| Time.parse a },
          description: 'CloudWatch metric statistics end time'
 
+  option :fetch_age,
+         description: 'How long ago to fetch metrics from',
+         short: '-f AGE',
+         long: '--fetch-age',
+         default: 0,
+         proc: proc(&:to_i)
+
   option :period,
          short:       '-p N',
          long:        '--period SECONDS',
@@ -95,8 +102,8 @@ class RDSMetrics < Sensu::Plugin::Metric::CLI::Graphite
           value: value
         }
       ],
-      start_time: config[:end_time] - config[:period],
-      end_time: config[:end_time],
+      start_time: config[:end_time] - config[:fetch_age] - config[:period],
+      end_time: config[:end_time] - config[:fetch_age],
       statistics: [config[:statistics].to_s.capitalize],
       period: config[:period]
     )

--- a/lib/sensu-plugins-aws/version.rb
+++ b/lib/sensu-plugins-aws/version.rb
@@ -1,8 +1,8 @@
 module SensuPluginsAWS
   module Version
     MAJOR = 11
-    MINOR = 5
-    PATCH = 1
+    MINOR = 6
+    PATCH = 0
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end
 end

--- a/lib/sensu-plugins-aws/version.rb
+++ b/lib/sensu-plugins-aws/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsAWS
   module Version
     MAJOR = 12
-    MINOR = 0
+    MINOR = 1
     PATCH = 0
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/sensu-plugins-aws/version.rb
+++ b/lib/sensu-plugins-aws/version.rb
@@ -2,7 +2,7 @@ module SensuPluginsAWS
   module Version
     MAJOR = 11
     MINOR = 5
-    PATCH = 0
+    PATCH = 1
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end
 end

--- a/lib/sensu-plugins-aws/version.rb
+++ b/lib/sensu-plugins-aws/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsAWS
   module Version
-    MAJOR = 11
-    MINOR = 6
+    MAJOR = 12
+    MINOR = 0
     PATCH = 0
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end

--- a/lib/sensu-plugins-aws/version.rb
+++ b/lib/sensu-plugins-aws/version.rb
@@ -1,7 +1,7 @@
 module SensuPluginsAWS
   module Version
     MAJOR = 12
-    MINOR = 1
+    MINOR = 2
     PATCH = 0
     VER_STRING = [MAJOR, MINOR, PATCH].compact.join('.')
   end


### PR DESCRIPTION
Previously, `check-s3-object.rb` would not return a satisfactory result if multiple matching objects were found. With that overridden, it would check against the first object in the list, which also appears to be the oldest object. This PR removes the limitation on returned objects and checks against the most recent (last) object in the returned list.

## Pull Request Checklist

This is not in reference to an existing issue.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass


#### Purpose
bugfix

#### Known Compatibility Issues
None at this time.