### PR TITLE
check-rds-pending: Handle no clusters properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- check-rds-pending: Fix issue if there are no RDS instances in a region. Previously this would raise an API exception (@stevenviola)
 
 ## [11.5.0] - 2018-05-17
 ### Added

--- a/bin/check-rds-pending.rb
+++ b/bin/check-rds-pending.rb
@@ -47,10 +47,12 @@ class CheckRDSEvents < Sensu::Plugin::Check::CLI
       # fetch all clusters identifiers
       clusters = rds.describe_db_instances[:db_instances].map { |db| db[:db_instance_identifier] }
       maint_clusters = []
-      # Check if there is any pending maintenance required
-      pending_record = rds.describe_pending_maintenance_actions(filters: [{ name: 'db-instance-id', values: clusters }])
-      pending_record[:pending_maintenance_actions].each do |response|
-        maint_clusters.push(response[:pending_maintenance_action_details])
+      if clusters.any?
+        # Check if there is any pending maintenance required
+        pending_record = rds.describe_pending_maintenance_actions(filters: [{ name: 'db-instance-id', values: clusters }])
+        pending_record[:pending_maintenance_actions].each do |response|
+          maint_clusters.push(response[:pending_maintenance_action_details])
+        end
       end
     rescue StandardError => e
       unknown "An error occurred processing AWS RDS API: #{e.message}"


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

When running `check-rds-pending` in a region that has no RDS instances, the check will return an Unknown status, and hit an issue in the API, causing the following output:

```
CheckRDSEvents UNKNOWN: An error occurred processing AWS RDS API: The list of DB Instance Identifiers must not be empty.
```

This is because an empty list of rds clusters is sent to the API to see if there is any pending maintenance action. The fix is to check if the list of clusters from the API is empty before checking if there are any pending maintenance actions. If the list is empty, than checking for the actions is skipped for that region.

With this Fix, no Unknown status is raised if there are no RDS clusters in a region.

#### Known Compatibility Issues

None
