### PR TITLE
Provide the --fetch-age option for the RDS metrics collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- metrics-rds.rb: adding option `--fetch-age` to allow getting metrics in the past (@multani)
 
 ## [11.5.0] - 2018-05-17
 ### Added

--- a/bin/metrics-rds.rb
+++ b/bin/metrics-rds.rb
@@ -57,6 +57,13 @@ class RDSMetrics < Sensu::Plugin::Metric::CLI::Graphite
          proc:        proc { |a| Time.parse a },
          description: 'CloudWatch metric statistics end time'
 
+  option :fetch_age,
+         description: 'How long ago to fetch metrics from',
+         short: '-f AGE',
+         long: '--fetch-age',
+         default: 0,
+         proc: proc(&:to_i)
+
   option :period,
          short:       '-p N',
          long:        '--period SECONDS',
@@ -95,8 +102,8 @@ class RDSMetrics < Sensu::Plugin::Metric::CLI::Graphite
           value: value
         }
       ],
-      start_time: config[:end_time] - config[:period],
-      end_time: config[:end_time],
+      start_time: config[:end_time] - config[:fetch_age] - config[:period],
+      end_time: config[:end_time] - config[:fetch_age],
       statistics: [config[:statistics].to_s.capitalize],
       period: config[:period]
     )


### PR DESCRIPTION
This allows to get metrics in the past in a more automated way than setting
the end_time directly.

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

This allows to easily get metrics in the past, without having to specify a new end date every time we call the metrics check.

This is needed as some metrics can take a long time to be aggregated by CloudWatch and might not be available for several minutes compared to the time they were generated.

#### Known Compatibility Issues

None

#### Test artifact

Previously:

```
$ date && bundle exec bin/metrics-rds.rb --aws-region eu-central-1 -i main -p 60
Tue Jun 19 13:49:49 CEST 2018
main.databaseconnections 147.0 1529408880
main.freestoragespace 53066555392.0 1529408880
main.readiops 0.0 1529408880
main.readlatency 0.0 1529408880
main.readthroughput 0.0 1529408880
main.writeiops 4.066870010167175 1529408880
main.writelatency 0.00040111420612813365 1529408880
main.writethroughput 38503.683456115206 1529408880
main.swapusage 32153600.0 1529408880
main.binlogdiskusage 151391.0 1529408880
main.diskqueuedepth 0.001933430004833575 1529408880
```

Note that the CPU utilization doesn't appear here.

With a fetch age set slightly in the past:

```
$ date && bundle exec bin/metrics-rds.rb --aws-region eu-central-1 -i main -p 60 -f 60
Tue Jun 19 13:49:53 CEST 2018
main.cpuutilization 0.91666666790843 1529408820
main.databaseconnections 148.0 1529408820
main.freestoragespace 53066563584.0 1529408820
main.readiops 0.0 1529408820
main.readlatency 0.0 1529408820
main.readthroughput 0.0 1529408820
main.writeiops 4.317026418868239 1529408820
main.writelatency 0.00044444444444444447 1529408820
main.writethroughput 38366.50610843514 1529408820
main.swapusage 32153600.0 1529408820
main.binlogdiskusage 148232.0 1529408820
main.diskqueuedepth 0.0023333722228703812 1529408820
```