### PR TITLE
Up the period from 60 to 120

### DIFF
--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -93,7 +93,7 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
     config[:metric_name] = 'BurstBalance'
     config[:namespace] = 'AWS/EBS'
     config[:statistics] = 'Average'
-    config[:period] = 60
+    config[:period] = 120
     crit = false
     should_warn = false
 


### PR DESCRIPTION
When `config[:period]` is at 60, `client.get_metric_statistics()` will return from 0 to 2 results, which can result in a false positive if the returned value for resp.datapoints is a `[]`.

Setting this value to 120 will consistently return 2-3 results in the datapoints array. CloudWatch API does not guarantee that the values returned will be in time order, so I believe this should be a good compromise. `period` has to be in a multiple of 60, therefore 120 is the next best value.