### PR TITLE
Ebs burst fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- `check-ebs-burst-limit.rb`: Fixed period to pass to config from 60 to 120 so as to not have empty values returned sometimes
 
 ## [11.5.0] - 2018-05-17
 ### Added

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -93,7 +93,7 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
     config[:metric_name] = 'BurstBalance'
     config[:namespace] = 'AWS/EBS'
     config[:statistics] = 'Average'
-    config[:period] = 60
+    config[:period] = 120
     crit = false
     should_warn = false
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

When `config[:period]` is originally at 60, `client.get_metric_statistics()` will return from 0 to 2 results, which can result in a false positive if the returned value for resp.datapoints is a [].

Setting this value to 120 will consistently return 2-3 results in the `resp.datapoints` array. CloudWatch API does not guarantee that the values returned will be in time order, but I believe this should be a good compromise. `config[:period]` has to be in a multiple of 60, therefore 120 is the next best value to use here to get the results we need.