### PR TITLE
Adding new check: number of AWS instances running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Added
+- `check-instances-running.rb`: check a specific region never has more than a given number of instances running, allowing filter by tag (@jcastillocano)
+
 ## [12.0.0] - 2018-06-21
 ### Breaking Changes
 - `check-ebs-burst-limit.rb`: Fixed period to pass to config from 60 to 120 so as to not have empty values returned sometimes (@wari)

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@
 
 **check-instances-count.rb**
 
+**check-instances-running.rb**
+
 **check-vpc-vpn.rb**
 
 **handler-ec2_node.rb**
@@ -186,6 +188,8 @@
 * /bin/check-emr-steps.rb
 * /bin/check-eni-status.rb
 * /bin/check-instance-events.rb
+* /bin/check-instances-count.rb
+* /bin/check-instances-running.rb
 * /bin/check-rds-events.rb
 * /bin/check-rds-pending.rb
 * /bin/check-rds.rb
@@ -204,7 +208,6 @@
 * /bin/handler-ses.rb
 * /bin/handler-sns.rb
 * /bin/metrics-autoscaling-instance-count.rb
-* /bin/check-instances-count.rb
 * /bin/metrics-asg.rb
 * /bin/metrics-billing.rb
 * /bin/metrics-ec2-count.rb

--- a/bin/check-instances-running.rb
+++ b/bin/check-instances-running.rb
@@ -1,0 +1,99 @@
+#! /usr/bin/env ruby
+#
+# check-instances-running
+#
+#
+# DESCRIPTION:
+#   This plugin checks the instances running for a specific region.
+#   Goal is to allow you to monitor that your region runs certain
+#   number of EC2 instances
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#     check-instances-running.rb --warn 15 --crit 25 [--tags tag_name:tag_value,tag_name:tag_value]
+#
+#
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright (c) 2018, Juan Carlos Castillo Cano
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugins-aws'
+require 'sensu-plugin/check/cli'
+require 'aws-sdk'
+
+# Class to check the instance count
+class CheckInstancesRunning < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :tags,
+         description: 'Tag to use as filter',
+         short: '-t TAG',
+         long: '--tags TAGS',
+         required: false
+
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region REGION',
+         description: 'AWS Region (such as us-east-1).'
+
+  option :warn,
+         short: '-w COUNT',
+         long: '--warn COUNT',
+         proc: proc(&:to_i)
+
+  option :crit,
+         short: '-c COUNT',
+         long: '--crit COUNT',
+         proc: proc(&:to_i)
+
+  def filters
+    filter = [{ name: 'instance-state-name', values: ['running'] }]
+    if config.key?(:tags)
+      config[:tags].split(',').each do |tag|
+        name, value = tag.split(':')
+        filter << { name: "tag:#{name}", values: [value] }
+      end
+    end
+    filter
+  end
+
+  def instance_count
+    client = Aws::EC2::Client.new(region: config[:aws_region])
+    resp = client.describe_instances(filters: filters).to_h
+    instances = []
+    resp[:reservations].each do |insts|
+      insts[:instances].each do |i|
+        instances << i[:instance_id]
+      end
+    end
+    instances.length
+  rescue StandardError => e
+    critical "There was an error reaching AWS - #{e.message}"
+  end
+
+  def run
+    count = instance_count
+    msg_prefix = "#{count} instances running for region [ #{config[:aws_region]} ]"
+    if count >= config[:crit]
+      critical "#{msg_prefix} - critical threshold #{config[:crit]}"
+    elsif count >= config[:warn]
+      warning "#{msg_prefix} - warning threshold #{config[:warn]}, critical threshold #{config[:crit]}"
+    else
+      ok msg_prefix
+    end
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [x] Add the plugin to the README

- [x] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

To add a new check: verify the number of EC2 instances running in a region is below a threshold.
 
#### Known Compatibility Issues
