### PR TITLE
Update check-elb-sum-requests.rb to AWS SDK v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Breaking Changes
+- `check-elb-sum-requests.rb` was updated to aws-sdk v2 and no longer take `aws_access_key` and `aws_secret_access_key` options. (@boutetnico)
 
 ## [12.4.0] - 2018-10-03
 ### Changed
@@ -19,7 +21,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [12.1.0] - 2018-08-28
 ### Added
-- new `check-efs.rb: checks cloudwatch metrics with the efs namespace for an arbitrary metric (@ivanfetch)
+- new `check-efs.rb`: checks cloudwatch metrics with the efs namespace for an arbitrary metric (@ivanfetch)
 
 ## [12.0.0] - 2018-06-21
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Breaking Changes
-- `check-elb-sum-requests.rb` no longer take `aws_access_key` and `aws_secret_access_key` options. (@boutetnico)
+- `check-elb-sum-requests.rb` no longer takes `aws_access_key` and `aws_secret_access_key` options. (@boutetnico)
 
 ### Changed
 - `check-elb-sum-requests.rb` was updated to aws-sdk v2. (@boutetnico)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,10 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 ### Breaking Changes
-- `check-elb-sum-requests.rb` was updated to aws-sdk v2 and no longer take `aws_access_key` and `aws_secret_access_key` options. (@boutetnico)
+- `check-elb-sum-requests.rb` no longer take `aws_access_key` and `aws_secret_access_key` options. (@boutetnico)
+
+### Changed
+- `check-elb-sum-requests.rb` was updated to aws-sdk v2. (@boutetnico)
 
 ## [12.4.0] - 2018-10-03
 ### Changed

--- a/bin/check-elb-sum-requests.rb
+++ b/bin/check-elb-sum-requests.rb
@@ -124,7 +124,7 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
       next unless threshold
       next if metric_value < threshold
       flag_alert severity,
-                 "; #{elbs.size == 1 ? nil : "#{elb.inspect}'s"} Sum Requests is #{metric_value}. (expected lower than #{threshold})"
+                 "; #{elbs.size == 1 ? nil : "#{elb.load_balancer_name}'s"} Sum Requests is #{metric_value}. (expected lower than #{threshold})"
       break
     end
   end

--- a/bin/check-elb-sum-requests.rb
+++ b/bin/check-elb-sum-requests.rb
@@ -130,7 +130,11 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
   end
 
   def run
-    @message = "#{elbs.size} load balancers total"
+    @message = if elbs.size == 1
+                 elbs.first.load_balancer_name
+               else
+                 "#{elbs.size} load balancers total"
+               end
 
     @severities = {
       critical: false,

--- a/bin/check-elb-sum-requests.rb
+++ b/bin/check-elb-sum-requests.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk-v1
+#   gem: aws-sdk
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -31,20 +31,11 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'aws-sdk-v1'
+require 'sensu-plugins-aws'
+require 'aws-sdk'
 
 class CheckELBSumRequests < Sensu::Plugin::Check::CLI
-  option :aws_access_key,
-         short:       '-a AWS_ACCESS_KEY',
-         long:        '--aws-access-key AWS_ACCESS_KEY',
-         description: "AWS Access Key. Either set ENV['AWS_ACCESS_KEY'] or provide it as an option",
-         default:     ENV['AWS_ACCESS_KEY']
-
-  option :aws_secret_access_key,
-         short:       '-k AWS_SECRET_KEY',
-         long:        '--aws-secret-access-key AWS_SECRET_KEY',
-         description: "AWS Secret Access Key. Either set ENV['AWS_SECRET_KEY'] or provide it as an option",
-         default:     ENV['AWS_SECRET_KEY']
+  include Common
 
   option :aws_region,
          short:       '-r AWS_REGION',
@@ -79,42 +70,40 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
            description: "Trigger a #{severity} if sum requests is over specified count"
   end
 
-  def aws_config
-    { access_key_id: config[:aws_access_key],
-      secret_access_key: config[:aws_secret_access_key],
-      region: config[:aws_region] }
-  end
-
   def elb
-    @elb ||= AWS::ELB.new aws_config
+    @elb = Aws::ElasticLoadBalancing::Client.new(aws_config)
   end
 
   def cloud_watch
-    @cloud_watch ||= AWS::CloudWatch.new aws_config
+    @cloud_watch = Aws::CloudWatch::Client.new
   end
 
   def elbs
     return @elbs if @elbs
-    @elbs = elb.load_balancers.to_a
-    @elbs.select! { |elb| config[:elb_names].include? elb.name } if config[:elb_names]
+    @elbs = elb.describe_load_balancers.load_balancer_descriptions.to_a
+    @elbs.select! { |elb| config[:elb_names].include? elb.load_balancer_name } if config[:elb_names]
     @elbs
   end
 
-  def latency_metric(elb_name)
-    cloud_watch.metrics.with_namespace('AWS/ELB').with_metric_name('RequestCount').with_dimensions(name: 'LoadBalancerName', value: elb_name).first
-  end
-
-  def statistics_options
-    {
+  def request_count_metric(elb_name)
+    cloud_watch.get_metric_statistics(
+      namespace: 'AWS/ELB',
+      metric_name: 'RequestCount',
+      dimensions: [
+        {
+          name: 'LoadBalancerName',
+          value: elb_name
+        }
+      ],
       start_time: config[:end_time] - config[:period],
-      end_time:   config[:end_time],
+      end_time: config[:end_time],
       statistics: ['Sum'],
-      period:     config[:period]
-    }
+      period: config[:period]
+    )
   end
 
   def latest_value(metric)
-    metric.statistics(statistics_options.merge(unit: 'Count')).datapoints.sort_by { |datapoint| datapoint[:timestamp] }.last[:sum]
+    metric.datapoints.sort_by { |datapoint| datapoint[:timestamp] }.last[:sum]
   end
 
   def flag_alert(severity, message)
@@ -123,7 +112,7 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
   end
 
   def check_sum_requests(elb)
-    metric        = latency_metric elb.name
+    metric        = request_count_metric elb.load_balancer_name
     metric_value  = begin
                       latest_value metric
                     rescue StandardError
@@ -132,7 +121,6 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
 
     @severities.each_key do |severity|
       threshold = config[:"#{severity}_over"]
-      puts metric_value
       next unless threshold
       next if metric_value < threshold
       flag_alert severity,
@@ -142,11 +130,7 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
   end
 
   def run
-    @message = if elbs.size == 1
-                 elbs.first.inspect
-               else
-                 "#{elbs.size} load balancers total"
-               end
+    @message = "#{elbs.size} load balancers total"
 
     @severities = {
       critical: false,

--- a/bin/check-elb-sum-requests.rb
+++ b/bin/check-elb-sum-requests.rb
@@ -71,11 +71,11 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
   end
 
   def elb
-    @elb = Aws::ElasticLoadBalancing::Client.new(aws_config)
+    @elb ||= Aws::ElasticLoadBalancing::Client.new(aws_config)
   end
 
   def cloud_watch
-    @cloud_watch = Aws::CloudWatch::Client.new
+    @cloud_watch ||= Aws::CloudWatch::Client.new
   end
 
   def elbs

--- a/bin/check-elb-sum-requests.rb
+++ b/bin/check-elb-sum-requests.rb
@@ -143,7 +143,7 @@ class CheckELBSumRequests < Sensu::Plugin::Check::CLI
 
     elbs.each { |elb| check_sum_requests elb }
 
-    @message += "; (#{config[:statistics].to_s.capitalize} within #{config[:period]} seconds "
+    @message += "; (Sum within #{config[:period]} seconds "
     @message += "between #{config[:end_time] - config[:period]} to #{config[:end_time]})"
 
     if @severities[:critical]


### PR DESCRIPTION
**Disclosure: I'm not a Ruby programmer, I cannot run the test suite, please review my changes.**

## Pull Request Checklist

Issue related: https://github.com/sensu-plugins/sensu-plugins-aws/issues/240

#### General

- [X] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Update to AWS SDK v2.

#### Known Compatibility Issues

This is a breaking change because it removes `aws_access_key` and `aws_secret_access_key` options per #2.

#### Examples

**Before this PR**

Check all ELB in a region having 1 LB
```
$ ./check-elb-sum-requests.rb -a <key> -k <secret> -r eu-west-1
264.0
264.0
CheckELBSumRequests OK: <AWS::ELB::LoadBalancer name:my_lb>; ( within 60 seconds between 2018-10-28 07:55:37 +0000 to 2018-10-28 07:56:37 +0000)
```

Check all ELB in a region having 1 LB with a warning status
```
$ ./check-elb-sum-requests.rb -a <key> -k <secret> -r eu-west-1 --warning-over 10
351.0
351.0
CheckELBSumRequests WARNING: <AWS::ELB::LoadBalancer name:my_lb>;  Sum Requests is 351.0. (expected lower than 10.0); ( within 60 seconds between 2018-10-28 07:59:22 +0000 to 2018-10-28 08:00:22 +0000)
```

Check all ELB in a region having 2 LB
```
$ ./check-elb-sum-requests.rb -a <key> -k <secret> -r eu-west-1
126.0
126.0
0
0
CheckELBSumRequests OK: 2 load balancers total; ( within 60 seconds between 2018-10-28 08:50:16 +0000 to 2018-10-28 08:51:16 +0000)
```

Check all ELB in a region having 2 LB with a warning status
```
$ ./check-elb-sum-requests.rb -a <key> -k <secret> -r eu-west-1 --warning-over 10
206.0
206.0
0
0
CheckELBSumRequests WARNING: 2 load balancers total; <AWS::ELB::LoadBalancer name:my_lb>'s Sum Requests is 206.0. (expected lower than 10.0); ( within 60 seconds between 2018-10-28 08:51:07 +0000 to 2018-10-28 08:52:07 +0000)
```

**After this PR**

Check all ELB in a region having 1 LB
```
$ ./check-elb-sum-requests.rb -r eu-west-1
CheckELBSumRequests OK: my_lb; (Sum within 60 seconds between 2018-10-28 08:15:58 UTC to 2018-10-28 08:16:58 UTC)
```

Check all ELB in a region having 1 LB with a warning status
```
$ ./check-elb-sum-requests.rb -r eu-west-1 --warning-over 10
CheckELBSumRequests WARNING: my_lb;  Sum Requests is 215.0. (expected lower than 10.0); (Sum within 60 seconds between 2018-10-28 08:16:11 UTC to 2018-10-28 08:17:11 UTC)
```

Check all ELB in a region having 2 LB
```
$ ./check-elb-sum-requests.rb -r eu-west-1
CheckELBSumRequests OK: 2 load balancers total; (Sum within 60 seconds between 2018-10-28 08:58:10 UTC to 2018-10-28 08:59:10 UTC)
```

Check all ELB in a region having 2 LB with a warning status
```
$ ./check-elb-sum-requests.rb -r eu-west-1 --warning-over 10
CheckELBSumRequests WARNING: 2 load balancers total; my_lb's Sum Requests is 179.0. (expected lower than 10.0); (Sum within 60 seconds between 2018-10-28 08:59:55 UTC to 2018-10-28 09:00:55 UTC)
```