### PR TITLE
removing `aws-sdk-v1` from the gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Breaking Change
+- removed `asw-sdk-v1` as all assets have been upgraded to `aws-sdk-v2` this is technically not a breaking change but for safety reasons in case we missed anything we are versioning it as a major bump (@majormoses)
+
 ## [15.0.0] - 2018-11-01
 ### Breaking Changes
 - `check-elb-latency.rb` no longer takes `aws_access_key` and `aws_secret_access_key` options. (@boutetnico)

--- a/sensu-plugins-aws.gemspec
+++ b/sensu-plugins-aws.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'sensu-plugin',      '~> 2.0'
 
   s.add_runtime_dependency 'aws-sdk',           '~> 3.0'
-  s.add_runtime_dependency 'aws-sdk-v1',        '1.66.0'
   s.add_runtime_dependency 'erubis',            '2.7.0'
   s.add_runtime_dependency 'fog',               '1.32.0'
   # 1.44 requires xmlrpc which only supports >= ruby 2.3


### PR DESCRIPTION
All the assets should be updated to v2 so this should be safe to remove.


## Pull Request Checklist

closes #240 

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
Fully remove sdk-v1

#### Known Compatibility Issues
There should not be any but versioning it as a major just in case.