### PR TITLE
properly iterate over IPs in check-vpc-nameservers.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- removed codeclimate (@tmonk42)
 
 ## [16.1.0] - 2018-11-02
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://travis-ci.org/sensu-plugins/sensu-plugins-aws.svg?branch=master)](https://travis-ci.org/sensu-plugins/sensu-plugins-aws)
 [![Gem Version](https://badge.fury.io/rb/sensu-plugins-aws.svg)](https://badge.fury.io/rb/sensu-plugins-aws.svg)
-[![Code Climate](https://codeclimate.com/github/sensu-plugins/sensu-plugins-aws/badges/gpa.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-aws)
-[![Test Coverage](https://codeclimate.com/github/sensu-plugins/sensu-plugins-aws/badges/coverage.svg)](https://codeclimate.com/github/sensu-plugins/sensu-plugins-aws)
 
 ## Functionality
 

--- a/bin/check-vpc-nameservers.rb
+++ b/bin/check-vpc-nameservers.rb
@@ -65,7 +65,7 @@ class CheckVpcNameservers < Sensu::Plugin::Check::CLI
     options.dhcp_options.each do |option|
       option.dhcp_configurations.each do |map|
         next if map.key != 'domain-name-servers'
-        map.each_value do |value|
+        map.values.each do |value|
           ip = value.value
           config[:queries].each do |query|
             begin

--- a/sensu-plugins-aws.gemspec
+++ b/sensu-plugins-aws.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'right_aws',         '3.1.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
-  s.add_development_dependency 'codeclimate-test-reporter', '~> 1.0'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 12.3'

--- a/test/spec_helper.rb
+++ b/test/spec_helper.rb
@@ -1,6 +1,3 @@
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
-
 RSpec.configure do |c|
   c.formatter = :documentation
   c.color = true


### PR DESCRIPTION
check-vpc-nameservers.rb would fail with the following error when
attempting to validate the VPC nameservers on the DHCP option set:

    Check failed to run: undefined method `each_value' for
    #<Aws::EC2::Types::DhcpConfiguration:0x00556320a7a318>

This corrects the iterator so that that sensu check works as expected.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
