### PR TITLE
check-ec2-cpu_balance.rb: Make instance families configurable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
 - removed codeclimate (@tmonk42)
+
+### Added
+- `check-ec2-cpu_balance.rb`: adding option `--instance-families` to manage which instance families to check. (@cyrilgdn)
 
 ## [16.1.0] - 2018-11-02
 ### Changed

--- a/bin/check-ec2-cpu_balance.rb
+++ b/bin/check-ec2-cpu_balance.rb
@@ -63,7 +63,8 @@ class EC2CpuBalance < Sensu::Plugin::Check::CLI
          description: 'List of burstable instance families to check. Default to t2,t3',
          short: '-f t2,t3',
          long: '--instance-families t2,t3',
-         default: 't2,t3'
+         proc: proc { |x| x.split(',') },
+         default: %w[t2 t3]
 
   def data(instance)
     client = Aws::CloudWatch::Client.new
@@ -107,7 +108,7 @@ class EC2CpuBalance < Sensu::Plugin::Check::CLI
     level = 0
     instances.reservations.each do |reservation|
       reservation.instances.each do |instance|
-        next unless instance.instance_type.start_with?(*config[:instance_families].split(','))
+        next unless instance.instance_type.start_with?(*config[:instance_families])
         id = instance.instance_id
         result = data id
         tag = config[:tag] ? " (#{instance_tag(instance, config[:tag])})" : ''

--- a/bin/check-ec2-cpu_balance.rb
+++ b/bin/check-ec2-cpu_balance.rb
@@ -59,6 +59,12 @@ class EC2CpuBalance < Sensu::Plugin::Check::CLI
          short: '-t TAG',
          long: '--tag TAG'
 
+  option :instance_families,
+         description: 'List of burstable instance families to check. Default to t2,t3',
+         short: '-f t2,t3',
+         long: '--instance-families t2,t3',
+         default: 't2,t3'
+
   def data(instance)
     client = Aws::CloudWatch::Client.new
     stats = 'Average'
@@ -101,7 +107,7 @@ class EC2CpuBalance < Sensu::Plugin::Check::CLI
     level = 0
     instances.reservations.each do |reservation|
       reservation.instances.each do |instance|
-        next unless instance.instance_type.start_with? 't2.'
+        next unless instance.instance_type.start_with?(*config[:instance_families].split(','))
         id = instance.instance_id
         result = data id
         tag = config[:tag] ? " (#{instance_tag(instance, config[:tag])})" : ''


### PR DESCRIPTION
There's a new CPU burstable instance family: t3
I added it in the default value but thought it may be a good idea to add an option for that.
(So no need to wait for a plugin update when AWS will add another new burstable family.)

