### PR TITLE
Allow multiple metrics in metrics-cloudfront.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Changed
+- `metrics-cloudfront.rb` now accepts multiple metrics. (@boutetnico)
+
+### Breaking Changes
+- `metrics-cloudfront.rb` `--metric` option was renamed to `--metrics`. (@boutetnico)
 
 ## [16.2.0] - 2019-02-19
 ### Fixed

--- a/bin/metrics-cloudfront.rb
+++ b/bin/metrics-cloudfront.rb
@@ -108,7 +108,6 @@ class CloudFrontMetrics < Sensu::Plugin::Metric::CLI::Graphite
     end
   end
 
-
   def print_statistics(distribution_id, statistic)
     statistic.each do |metric, static|
       r = cloud_watch_metric(metric, static, distribution_id)
@@ -141,22 +140,20 @@ class CloudFrontMetrics < Sensu::Plugin::Metric::CLI::Graphite
     if metrics.nil?
       unknown 'No metrics provided. See usage for details'
     end
-    ret = metrics.split(',')
+    metrics.split(',')
   end
 
   def run
-    begin
-      metrics = parse_metrics(config[:metrics])
+    metrics = parse_metrics(config[:metrics])
 
-      if config[:distribution_id].nil?
-        distribution_list(metrics).each do |distribution|
-          print_metrics(distribution, metrics)
-        end
-      else
-        print_metrics(config[:distribution_id], metrics)
+    if config[:distribution_id].nil?
+      distribution_list(metrics).each do |distribution|
+        print_metrics(distribution, metrics)
       end
-
-      ok
+    else
+      print_metrics(config[:distribution_id], metrics)
     end
+
+    ok
   end
 end


### PR DESCRIPTION
Disclaimer: I'm not a Ruby programmer, please review my changes and provide feedback. Thanks!

## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Allow to fetch multiple metrics at once instead of only one.

Usage before this PR:
```
$ ruby metrics-cloudfront.rb -p 86400 --metric Requests
aws.cloudfront.AAAAAAAAAAAAAA.Requests.Sum 2287529.0 1549097536

$ ruby metrics-cloudfront.rb -p 86400 --metric BytesDownloaded
aws.cloudfront.AAAAAAAAAAAAAA.BytesDownloaded.Sum 29040049343.0 1549097536
```

Usage after this PR:
```
$ ruby metrics-cloudfront.rb -p 86400 --metrics Requests,BytesDownloaded
aws.cloudfront.AAAAAAAAAAAAAA.Requests.Sum 2287529.0 1549097536
aws.cloudfront.AAAAAAAAAAAAAA.BytesDownloaded.Sum 29040049343.0 1549097536

$ ruby metrics-cloudfront.rb -p 86400 -m Requests,DoesNotExist
aws.cloudfront.AAAAAAAAAAAAAA.Requests.Sum 1467626.0 1549098006
Invalid metric DoesNotExist. Possible values: Requests,BytesDownloaded,BytesUploaded,TotalErrorRate,4xxErrorRate,5xxErrorRate
```

#### Known Compatibility Issues

**Breaking change**: `--metric` option is renamed to `--metrics`. Short version of the option `-m` remains.