### PR TITLE
properly iterate over IPs in check-vpc-nameservers.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 - removed codeclimate (@tmonk42)
+- properly iterate over IPs in check-vpc-nameservers.rb (@masneyb)
 
 ## [16.1.0] - 2018-11-02
 ### Changed

--- a/bin/check-vpc-nameservers.rb
+++ b/bin/check-vpc-nameservers.rb
@@ -65,7 +65,7 @@ class CheckVpcNameservers < Sensu::Plugin::Check::CLI
     options.dhcp_options.each do |option|
       option.dhcp_configurations.each do |map|
         next if map.key != 'domain-name-servers'
-        map.values.each do |value|
+        map.each_value do |value|
           ip = value.value
           config[:queries].each do |query|
             begin

--- a/bin/check-vpc-nameservers.rb
+++ b/bin/check-vpc-nameservers.rb
@@ -63,9 +63,9 @@ class CheckVpcNameservers < Sensu::Plugin::Check::CLI
     options = ec2.describe_dhcp_options(dhcp_options_ids: [dhcp_option_id])
 
     options.dhcp_options.each do |option|
-      option.dhcp_configurations.each do |map|
-        next if map.key != 'domain-name-servers'
-        map.each_value do |value|
+      option.dhcp_configurations.each do |configs|
+        next if configs.key != 'domain-name-servers'
+        configs.values.each do |value|
           ip = value.value
           config[:queries].each do |query|
             begin

--- a/bin/check-vpc-nameservers.rb
+++ b/bin/check-vpc-nameservers.rb
@@ -65,7 +65,7 @@ class CheckVpcNameservers < Sensu::Plugin::Check::CLI
     options.dhcp_options.each do |option|
       option.dhcp_configurations.each do |map|
         next if map.key != 'domain-name-servers'
-        map.each_value do |value|
+        map.values.each do |value|
           ip = value.value
           config[:queries].each do |query|
             begin

--- a/bin/check-vpc-nameservers.rb
+++ b/bin/check-vpc-nameservers.rb
@@ -63,9 +63,9 @@ class CheckVpcNameservers < Sensu::Plugin::Check::CLI
     options = ec2.describe_dhcp_options(dhcp_options_ids: [dhcp_option_id])
 
     options.dhcp_options.each do |option|
-      option.dhcp_configurations.each do |configs|
-        next if configs.key != 'domain-name-servers'
-        configs.values.each do |value|
+      option.dhcp_configurations.each do |map|
+        next if map.key != 'domain-name-servers'
+        map.values.each do |value| # rubocop:disable Performance/HashEachMethods
           ip = value.value
           config[:queries].each do |query|
             begin


### PR DESCRIPTION
check-vpc-nameservers.rb would fail with the following error when
attempting to validate the VPC nameservers on the DHCP option set:

    Check failed to run: undefined method `each_value' for
    #<Aws::EC2::Types::DhcpConfiguration:0x00556320a7a318>

This corrects the iterator so that that sensu check works as expected.

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
