### PR TITLE
Argument to exclude specific queues from check-sqs-messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-sqs-messages.rb`: adding option `--exclude-queue` for use in blacklisting specific queues in conjunction with `--prefix` flag. (@ruke47)
+
 ### Changed
 - `metrics-cloudfront.rb` now accepts multiple metrics. (@boutetnico)
 


### PR DESCRIPTION
I want to check all queues matching a prefix _except for_ a specific queue that I know to have a very bursty write load.

## Pull Request Checklist

**Is this in reference to an existing issue?**

No.

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Allows exclusion of queues from prefix-based monitoring, if they are known to have different operating characteristics.

#### Known Compatibility Issues

None