### PR TITLE
Support checking only a single db instance by name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+
+### Added
+
+- `check-rds-pending.rb`: adding option `--db-instance-identifier` to support checking only a single db instance for pending maintenance events, instead of all instances in a region. (@mattdoller)
+
 ### Changed
 - `metrics-cloudfront.rb` now accepts multiple metrics. (@boutetnico)
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

no

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

(n/a)

- [ ] Binstubs are created if needed

(n/a)

- [x] RuboCop passes

- [x] Existing tests pass

#### Purpose

Adds an optional parameter of --db-instance-identifier.  When
provided, this check will check only the given db instance for
pending maintenance actions.  When absent, the check will perform
as it always has, and check all db instances in the region.

#### Known Compatibility Issues
