### PR TITLE
Allow filtering in check-ec2-cpu_balance.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-ec2-cpu_balance.rb`: `--filter` option added to filter which instance to check. (@boutetnico)
 
 ## [18.0.0] - 2019-04-2
 ### Breaking Changes

--- a/bin/check-ec2-cpu_balance.rb
+++ b/bin/check-ec2-cpu_balance.rb
@@ -104,10 +104,10 @@ class EC2CpuBalance < Sensu::Plugin::Check::CLI
 
   def run
     filters = Filter.parse(config[:filter])
-    filters.push({
+    filters.push(
       name: 'instance-state-name',
       values: ['running']
-    })
+    )
     ec2 = Aws::EC2::Client.new
     instances = ec2.describe_instances(
       filters: filters


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Add `-F` or `--filter` option to limit which instances are considered.

Example:

Limit to instances having any tag with `staging` as value.
```
ruby check-ec2-cpu_balance.rb -F "{name:tag-value,values:[staging]}"
```
#### Known Compatibility Issues

None