### PR TITLE
Add filtering option in check-ebs-burst-limit.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-ebs-burst-limit.rb`: `--filter` option added to filter which volume to check. (@boutetnico)
 
 ## [18.2.0] - 2019-05-06
 ### Added

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -82,18 +82,14 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
       Aws.config[:region] = my_instance_az.chop
       my_instance_id = Net::HTTP.get(URI.parse('http://169.254.169.254/latest/meta-data/instance-id'))
       volume_filters.push(
-        {
-          name: 'attachment.instance-id',
-          values: [my_instance_id]
-        }
+        name: 'attachment.instance-id',
+        values: [my_instance_id]
       )
     else
       # The -s option was not specified, look at all volumes which are attached
-     volume_filters.push(
-        {
-          name: 'attachment.status',
-          values: ['attached']
-        }
+      volume_filters.push(
+        name: 'attachment.status',
+        values: ['attached']
       )
     end
 


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Add `--filter` / `-f` option to the plugin to allow filtering.

Example:

Limit to volumes having any tag with staging as value.

`ruby check-ebs-burst-limit.rb -f "{name:tag-value,values:[staging]}"`

#### Known Compatibility Issues

None