### PR TITLE
Fix db_cluster_id checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- Properly parse `--db-cluster-id` option in `check-rds.rb` (@rwha)
 
 ## [18.4.0] - 2019-05-08
 ### Added

--- a/bin/check-rds.rb
+++ b/bin/check-rds.rb
@@ -161,7 +161,7 @@ class CheckRDS < Sensu::Plugin::Check::CLI
 
   def find_db_cluster_writer(id)
     wr = rds.describe_db_clusters(db_cluster_identifier: id).db_clusters[0].db_cluster_members.detect(&:is_cluster_writer).db_instance_identifier
-    unknown 'DB cluster not found.' if cl.nil?
+    unknown 'DB cluster not found.' if wr.nil?
     wr
   end
 
@@ -321,7 +321,7 @@ class CheckRDS < Sensu::Plugin::Check::CLI
   def run
     instances = []
     if config[:db_cluster_id]
-      db_cluster_writer_id = find_db_cluster_writer(db_cluster_id)
+      db_cluster_writer_id = find_db_cluster_writer(config[:db_cluster_id])
       instances << find_db_instance(db_cluster_writer_id)
     end
 


### PR DESCRIPTION
## Pull Request Checklist

No existing issues found, but resolves an error when using `--db-cluster-id`

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
When an RDS DB Cluster ID is provided instead of an instance ID the check fails due to undefined local variables. This changes two lines to properly parse the `--db-cluster-id` option. 

#### Known Compatibility Issues
None.