### PR TITLE
Add tag option in check-ebs-burst-limit.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-ebs-burst-limit.rb`: add `--tag`/`-t` option to specify a volume tag to output in status message. (@boutetnico)
+
 ## [18.5.0] - 2020-01-28
 ### Changed
 - `check-trustedadvisor-service-limits.rb`: Trusted Advisor combined Service Limits check ID 'eW7HH0l7J9' scheduled to be disabled on Feb 15 2020. Updated the script to go through every Service Limits checks and look for not 'ok' status. Outcome is the same. (@swibowo)

--- a/bin/check-ebs-burst-limit.rb
+++ b/bin/check-ebs-burst-limit.rb
@@ -19,8 +19,10 @@
 # USAGE:
 #   ./check-ebs-burst-limit.rb -r ${you_region}
 #   ./check-ebs-burst-limit.rb -r ${you_region} -c 50
+#   ./check-ebs-burst-limit.rb -r ${you_region} -c 50 -t Name
 #   ./check-ebs-burst-limit.rb -r ${you_region} -w 50 -c 10
 #   ./check-ebs-burst-limit.rb -r ${you_region} -w 50 -c 10 -f "{name:tag-value,values:[infrastructure]}"
+#   ./check-ebs-burst-limit.rb -r ${you_region} -w 50 -c 10 -f "{name:tag-value,values:[infrastructure]}" -t Name
 #
 # LICENSE:
 #   Barry Martin <nyxcharon@gmail.com>
@@ -43,6 +45,11 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
          long:        '--region REGION',
          description: 'AWS region, will be overridden by the -s option',
          default: 'us-east-1'
+
+  option :tag,
+         description: 'Add volume TAG value to warn/critical message.',
+         short: '-t TAG',
+         long: '--tag TAG'
 
   option :critical,
          description: 'Trigger a critical when ebs burst limit is under VALUE',
@@ -69,6 +76,11 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
          long: '--filter FILTER',
          description: 'String representation of the filter to apply',
          default: '{}'
+
+  def volume_tag(volume, tag_name)
+    tag = volume.tags.select { |t| t.key == tag_name }.first
+    tag.nil? ? '' : tag.value
+  end
 
   def run
     errors = []
@@ -107,13 +119,14 @@ class CheckEbsBurstLimit < Sensu::Plugin::Check::CLI
     volumes[:volumes].each do |volume|
       config[:dimensions] = []
       config[:dimensions] << { name: 'VolumeId', value: volume[:volume_id] }
+      volume_tag = config[:tag] ? " (#{volume_tag(volume, config[:tag])})" : ''
       resp = client.get_metric_statistics(metrics_request(config))
       unless resp.datapoints.first.nil?
         if resp.datapoints.first[:average] < config[:critical]
-          errors << "#{volume[:volume_id]} #{resp.datapoints.first[:average]}"
+          errors << "#{volume[:volume_id]}#{volume_tag} #{resp.datapoints.first[:average]}"
           crit = true
         elsif config[:warning] && resp.datapoints.first[:average] < config[:warning]
-          errors << "#{volume[:volume_id]} #{resp.datapoints.first[:average]}"
+          errors << "#{volume[:volume_id]}#{volume_tag} #{resp.datapoints.first[:average]}"
           should_warn = true
         end
       end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Add a new option to `check-ebs-burst-limit.rb` allowing to pass a TAG name to output as well as volume id.

Example output before the PR:

```
CheckEbsBurstLimit CRITICAL: Volume(s) have exceeded critical threshold: ["vol-XXXXXXX 99.0"]
```

Example after the PR:

```
CheckEbsBurstLimit CRITICAL: Volume(s) have exceeded critical threshold: ["vol-XXXXXXX (staging-volume01) 99.0]"
```

#### Known Compatibility Issues

 None