### PR TITLE
Add new plugin metrics-reservation-utilization.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- new `metrics-reservation-utilization.rb`: retrieve metrics about reserved instances usage. (@boutetnico)
+
 ## [18.5.0] - 2020-01-28
 ### Changed
 - `check-trustedadvisor-service-limits.rb`: Trusted Advisor combined Service Limits check ID 'eW7HH0l7J9' scheduled to be disabled on Feb 15 2020. Updated the script to go through every Service Limits checks and look for not 'ok' status. Outcome is the same. (@swibowo)

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ The Sensu assets packaged from this repository are built against the Sensu Ruby 
 * /bin/metrics-elb.rb
 * /bin/metrics-emr-steps.rb
 * /bin/metrics-rds.rb
+* /bin/metrics-reservation-utilization.rb
 * /bin/metrics-s3.rb
 * /bin/metrics-ses.rb
 * /bin/metrics-sqs.rb

--- a/bin/metrics-reservation-utilization.rb
+++ b/bin/metrics-reservation-utilization.rb
@@ -37,7 +37,7 @@ class ReservationUtilizationMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :from,
          short:       '-f TIME',
          long:        '--from TIME',
-         default:     Time.now - 2 * 86400, # start date cannot be after 2 days ago
+         default:     Time.now - 2 * 86_400, # start date cannot be after 2 days ago
          proc:        proc { |a| Time.parse a },
          description: 'The beginning of the time period that you want the usage and costs for (inclusive).'
 
@@ -64,19 +64,18 @@ class ReservationUtilizationMetrics < Sensu::Plugin::Metric::CLI::Graphite
     begin
       client = Aws::CostExplorer::Client.new(aws_config)
 
-      reservation_utilization = client.get_reservation_utilization({
+      reservation_utilization = client.get_reservation_utilization(
         time_period: {
-          start: config[:from].strftime("%Y-%m-%d"),
-          end: config[:to].strftime("%Y-%m-%d"),
+          start: config[:from].strftime('%Y-%m-%d'),
+          end: config[:to].strftime('%Y-%m-%d')
         }
-      })
+      )
 
       reservation_utilization.utilizations_by_time.each do |time|
         time.total.to_h.each do |key, value|
           output "#{config[:scheme]}.utilizations_by_time.#{key}", value, Time.parse(time.time_period.end).to_i
         end
       end
-
     rescue StandardError => e
       critical "Error: exception: #{e}"
     end

--- a/bin/metrics-reservation-utilization.rb
+++ b/bin/metrics-reservation-utilization.rb
@@ -1,0 +1,85 @@
+#! /usr/bin/env ruby
+#
+# reservation-utilization
+#
+# DESCRIPTION:
+#   Gets Reservation Utilization of an AWS account.
+#
+# OUTPUT:
+#   metric-data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#   gem: sensu-plugins-aws
+#
+# USAGE:
+#   metrics-reservation-utilization.rb
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright (c) 2019, Nicolas Boutet amd3002@gmail.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/metric/cli'
+require 'aws-sdk'
+require 'sensu-plugins-aws'
+
+class ReservationUtilizationMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  include Common
+
+  option :from,
+         short:       '-f TIME',
+         long:        '--from TIME',
+         default:     Time.now - 2 * 86400, # start date cannot be after 2 days ago
+         proc:        proc { |a| Time.parse a },
+         description: 'The beginning of the time period that you want the usage and costs for (inclusive).'
+
+  option :to,
+         short:       '-t TIME',
+         long:        '--to TIME',
+         default:     Time.now,
+         proc:        proc { |a| Time.parse a },
+         description: 'The end of the time period that you want the usage and costs for (exclusive).'
+
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric.',
+         short:       '-s SCHEME',
+         long:        '--scheme SCHEME',
+         default:     'sensu.aws.reservation_utilization'
+
+  option :aws_region,
+         short:       '-r AWS_REGION',
+         long:        '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default:     'us-east-1'
+
+  def run
+    begin
+      client = Aws::CostExplorer::Client.new(aws_config)
+
+      reservation_utilization = client.get_reservation_utilization({
+        time_period: {
+          start: config[:from].strftime("%Y-%m-%d"),
+          end: config[:to].strftime("%Y-%m-%d"),
+        }
+      })
+
+      reservation_utilization.utilizations_by_time.each do |time|
+        time.total.to_h.each do |key, value|
+          output "#{config[:scheme]}.utilizations_by_time.#{key}", value, Time.parse(time.time_period.end).to_i
+        end
+      end
+
+    rescue StandardError => e
+      critical "Error: exception: #{e}"
+    end
+    ok
+  end
+end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [x] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

New plugin allowing to retrieve metrics about Reserved Instances utilization.

Example usage:

```
$ ruby /etc/sensu/plugins/metrics-reservation-utilization.rb
sensu.aws.reservation_utilization.utilizations_by_time.utilization_percentage 100 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.purchased_hours 1584 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.total_actual_hours 1584 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.unused_hours 0 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.on_demand_cost_of_ri_hours_used 30.288 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.net_ri_savings 9.936 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.total_potential_ri_savings 9.936 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.amortized_upfront_fee 0 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.amortized_recurring_fee 20.352 1563667200
sensu.aws.reservation_utilization.utilizations_by_time.total_amortized_fee 20.352 1563667200
```

#### Known Compatibility Issues

None