### PR TITLE
Add new plugin check-expiring-reservations.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- new `check-expiring-reservations.rb`: check instance reservations and warn about upcoming expiration. (@boutetnico)
+
 ## [18.5.0] - 2020-01-28
 ### Changed
 - `check-trustedadvisor-service-limits.rb`: Trusted Advisor combined Service Limits check ID 'eW7HH0l7J9' scheduled to be disabled on Feb 15 2020. Updated the script to go through every Service Limits checks and look for not 'ok' status. Outcome is the same. (@swibowo)

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ The Sensu assets packaged from this repository are built against the Sensu Ruby 
 * /bin/check-emr-cluster.rb
 * /bin/check-emr-steps.rb
 * /bin/check-eni-status.rb
+* /bin/check-expiring-reservations.rb
 * /bin/check-instance-events.rb
 * /bin/check-rds-events.rb
 * /bin/check-rds-pending.rb

--- a/bin/check-expiring-reservations.rb
+++ b/bin/check-expiring-reservations.rb
@@ -17,7 +17,7 @@
 #   gem: sensu-plugins-aws
 #
 # USAGE:
-#   metrics-reservation-utilization.rb
+#   check-expiring-reservations.rb
 #
 # NOTES:
 #

--- a/bin/check-expiring-reservations.rb
+++ b/bin/check-expiring-reservations.rb
@@ -1,0 +1,117 @@
+#! /usr/bin/env ruby
+#
+# expiring-reservations
+#
+# DESCRIPTION:
+#   Alert on expiring reservations of an AWS account.
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#   gem: sensu-plugins-aws
+#
+# USAGE:
+#   metrics-reservation-utilization.rb
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright (c) 2019, Nicolas Boutet amd3002@gmail.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/check/cli'
+require 'aws-sdk'
+require 'sensu-plugins-aws'
+
+class CheckExpiringReservations < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :reservation_id,
+         description: 'Reservation id (defaults to all reservations if omitted)',
+         short:       '-R RESERVATION_ID',
+         long:        '--reservation-id RESERVATION_ID',
+         default:     nil
+
+  option :offering_class,
+         description: 'The offering class of the Reserved Instance (standard or convertible)',
+         short:       '-o OFFERING_CLASS',
+         long:        '--offering-class OFFERING_CLASS',
+         default:     'standard'
+
+  option :aws_region,
+         short:       '-r AWS_REGION',
+         long:        '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default:     'us-east-1'
+
+  option :warning,
+         short:       '-w N',
+         long:        '--warning VALUE',
+         description: 'Issue a warning if a reservation will expire in under VALUE days',
+         default:     0,
+         proc:        proc(&:to_i)
+
+  option :critical,
+         short:       '-c N',
+         long:        '--critical VALUE',
+         description: 'Issue a critical if a reservation will expire in under VALUE days',
+         default:     1,
+         proc:        proc(&:to_i)
+
+  def run
+    begin
+      client = Aws::EC2::Client.new(aws_config)
+
+      params = {
+        filters: [
+          {
+            name: "state",
+            values: ["active"],
+          }
+        ],
+        offering_class: config[:offering_class]
+      }
+
+      unless config[:reservation_id].nil?
+        params[:reserved_instances_ids] = [config[:reservation_id]]
+      end
+
+      reservations = client.describe_reserved_instances(params)
+
+      warnflag = false
+      critflag = false
+      reportstring = ""
+
+      reservations.reserved_instances.each do |reservation|
+        time_left = (reservation.end - Time.now).abs.to_i / (24 * 60 * 60)
+
+        if time_left <= config[:critical]
+          critflag = true
+          reportstring += " reservation #{reservation.reserved_instances_id} (#{reservation.instance_type} x #{reservation.instance_count}) expires in #{time_left} days;"
+        elsif time_left <= config[:warning]
+          warnflag = true
+          reportstring += " reservation #{reservation.reserved_instances_id} (#{reservation.instance_type} x #{reservation.instance_count}) expires in #{time_left} days;"
+        end
+      end
+
+      if critflag
+        critical reportstring
+      elsif warnflag
+        warning reportstring
+      else
+        ok "All checked reservations are ok"
+      end
+    rescue StandardError => e
+      critical "Error: exception: #{e}"
+    end
+    ok
+  end
+end

--- a/bin/check-expiring-reservations.rb
+++ b/bin/check-expiring-reservations.rb
@@ -73,8 +73,8 @@ class CheckExpiringReservations < Sensu::Plugin::Check::CLI
       params = {
         filters: [
           {
-            name: "state",
-            values: ["active"],
+            name: 'state',
+            values: ['active']
           }
         ],
         offering_class: config[:offering_class]
@@ -88,7 +88,7 @@ class CheckExpiringReservations < Sensu::Plugin::Check::CLI
 
       warnflag = false
       critflag = false
-      reportstring = ""
+      reportstring = ''
 
       reservations.reserved_instances.each do |reservation|
         time_left = (reservation.end - Time.now).abs.to_i / (24 * 60 * 60)
@@ -107,7 +107,7 @@ class CheckExpiringReservations < Sensu::Plugin::Check::CLI
       elsif warnflag
         warning reportstring
       else
-        ok "All checked reservations are ok"
+        ok 'All checked reservations are ok'
       end
     rescue StandardError => e
       critical "Error: exception: #{e}"


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [x] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Warn about upcoming instance reservations expiration.

Example usage:

Check all reservations in a region:
```
$ ruby check-expiring-reservations.rb -r eu-west-1
CheckExpiringReservations OK: All checked reservations are ok
```

Check if a specific reservation `<reservation_id>` expires before 15 days with critical status:
```
$ ruby check-expiring-reservations.rb -r eu-west-1 -R <reservation_id> -c 15
CheckExpiringReservations CRITICAL:  reservation <reservation_id> (r5.xlarge x 1) expires in 11 days;
```

Warn if any reservation in the region expires before 30 days:
```
$ ruby check-expiring-reservations.rb -r eu-west-1 -w 30
CheckExpiringReservations WARNING:  reservation <reservation_id> (c5.large x 4) expires in 21 days; reservation <reservation_id> (r5.xlarge x 1) expires in 11 days;
```

#### Known Compatibility Issues

None