### PR TITLE
Address CVE-2019-5477 with nokogiri

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins
 
 ## [Unreleased]
 
+### Security
+- force newer version of nokogiri to address CVE-2019-5477 (@majormoses)
+
 ## [18.4.0] - 2019-05-08
 ### Added
 - `check-ebs-burst-limit.rb`: `--filter` option added to filter which volume to check. (@boutetnico)

--- a/sensu-plugins-aws.gemspec
+++ b/sensu-plugins-aws.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   # 1.44 requires xmlrpc which only supports >= ruby 2.3
   # https://github.com/fog/fog-core/issues/206
   s.add_runtime_dependency 'fog-core',          '1.43.0'
+  s.add_runtime_dependency 'nokogiri',          ['>= 1.10.4', '< 2.0']
   s.add_runtime_dependency 'rest-client',       '1.8.0'
   s.add_runtime_dependency 'right_aws',         '3.1.0'
 


### PR DESCRIPTION
Its an upstream dependency so we are gonna manually lock it so it must work with what we are using.

Signed-off-by: Ben Abrams <me@benabrams.it>

## Pull Request Checklist

https://github.com/sparklemotion/nokogiri/issues/1915

#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose

Address known CVE reported via hackerone.com

#### Known Compatibility Issues

none
