### PR TITLE
Add --warn-only to check-subnet-ip-consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-subnet-ip-consumption.rb` - Added `--warn-only` option (@ChrisCalavera)
 
 ## [18.4.2] - 2019-09-23
 ### Fixed

--- a/bin/check-subnet-ip-consumption.rb
+++ b/bin/check-subnet-ip-consumption.rb
@@ -74,6 +74,13 @@ class CheckSubnetIpConsumption < Sensu::Plugin::Check::CLI
          default:     0,
          description: 'Manipulate the verbosity of the alert output. Valid options are 0, 1, and 2 (from least to most verbose). Default is 0.'
 
+  option :warn_only,
+         short:       '-w',
+         long:        '--warn-only',
+         boolean:     true,
+         default:     false,
+         description: 'Warning only'
+
   def iam_client
     @iam_client ||= Aws::IAM::Client.new
   end
@@ -218,16 +225,23 @@ class CheckSubnetIpConsumption < Sensu::Plugin::Check::CLI
 
       case config[:show_account_alias]
       when true
-        critical(alert_prefix_with_alias % { count: alert_msg.length,
-                                             alias: account_alias,
-                                             region: config[:aws_region],
-                                             threshold: config[:alert_threshold],
-                                             alerts: alert_msg.join(', ') })
+        alert_msg = alert_prefix_with_alias % { count: alert_msg.length,
+                                                alias: account_alias,
+                                                region: config[:aws_region],
+                                                threshold: config[:alert_threshold],
+                                                alerts: alert_msg.join(', ') }
       when false
-        critical(alert_prefix % { count: alert_msg.length,
-                                  region: config[:aws_region],
-                                  threshold: config[:alert_threshold],
-                                  alerts: alert_msg.join(', ') })
+        alert_msg = alert_prefix % { count: alert_msg.length,
+                                     region: config[:aws_region],
+                                     threshold: config[:alert_threshold],
+                                     alerts: alert_msg.join(', ') }
+      end
+
+      case config[:warn_only]
+      when true
+        warning(alert_msg)
+      when false
+        critical(alert_msg)
       end
     end
   end


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

#### Known Compatibility Issues
