### PR TITLE
Updating the usage example - aws-region option

### DIFF
--- a/bin/check-cloudwatch-alarms.rb
+++ b/bin/check-cloudwatch-alarms.rb
@@ -17,7 +17,7 @@
 #
 # USAGE:
 #   ./check-cloudwatch-alarms --exclude-alarms "CPUAlarmLow"
-#   ./check-cloudwatch-alarms --region eu-west-1 --exclude-alarms "CPUAlarmLow"
+#   ./check-cloudwatch-alarms --aws-region eu-west-1 --exclude-alarms "CPUAlarmLow"
 #
 # NOTES:
 #


### PR DESCRIPTION
#### Purpose

Incorrect usage was given in the example (--region option instead of --aws-region)
