### PR TITLE
Prevent retrieval of all db instances when db_cluster_id is provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Fixed
+- Prevent the retrieval of all db instances when the `db_cluster_id` option is specified and the `db_instance_id` option is not specified
 
 ## [18.4.2] - 2019-09-23
 ### Fixed

--- a/bin/check-rds.rb
+++ b/bin/check-rds.rb
@@ -323,9 +323,7 @@ class CheckRDS < Sensu::Plugin::Check::CLI
     if config[:db_cluster_id]
       db_cluster_writer_id = find_db_cluster_writer(config[:db_cluster_id])
       instances << find_db_instance(db_cluster_writer_id)
-    end
-
-    if config[:db_instance_id].nil? || config[:db_instance_id].empty?
+    elsif config[:db_instance_id].nil? || config[:db_instance_id].empty?
       rds.describe_db_instances[:db_instances].map { |db| instances << db }
     else
       instances << find_db_instance(config[:db_instance_id])


### PR DESCRIPTION

Fix:  When specifying db_cluster_id and not providing db_instance_id... all db instances are retrieved.  If a db_cluster_id option is provided the only db instance retrieved will be the cluster's writable db instance, if found.