### PR TITLE
Trusted Advisor Service Limits check ID eW7HH0l7J9 deprecated.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 before_install:
   gem install bundler -v 1.15
 install:
-- bundle _1.15.0_ install
+- bundle install
 rvm:
 - 2.3.0
 - 2.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services: docker
 cache:
 - bundler
 before_install:
-  gem install bundler -v 1.15
+  gem install bundler -v 2.1
 install:
 - bundle install
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ cache:
 before_install:
   gem install bundler -v 1.15
 install:
-- bundle install
+- bundle _1.15.0_ install
 rvm:
 - 2.3.0
 - 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+- `check-trustedadvisor-service-limits.rb`: Trusted Advisor combined Service Limits check ID 'eW7HH0l7J9' scheduled to be disabled on Feb 15 2020. Updated the script to go through every Service Limits checks and look for not 'ok' status. Outcome is the same.
 
 ## [18.4.2] - 2019-09-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
-- `check-trustedadvisor-service-limits.rb`: Trusted Advisor combined Service Limits check ID 'eW7HH0l7J9' scheduled to be disabled on Feb 15 2020. Updated the script to go through every Service Limits checks and look for not 'ok' status. Outcome is the same.
+### Changed
+- `check-trustedadvisor-service-limits.rb`: Trusted Advisor combined Service Limits check ID 'eW7HH0l7J9' scheduled to be disabled on Feb 15 2020. Updated the script to go through every Service Limits checks and look for not 'ok' status. Outcome is the same. (@swibowo)
+- bumped version of `bundler` when installing to match travis, before installing dep ensure we have a required version of bundler for development (@majormoses)
 
 ## [18.4.2] - 2019-09-23
 ### Fixed

--- a/sensu-plugins-aws.gemspec
+++ b/sensu-plugins-aws.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s| # rubocop:disable Metrics/BlockLength
   s.add_runtime_dependency 'rest-client',       '1.8.0'
   s.add_runtime_dependency 'right_aws',         '3.1.0'
 
-  s.add_development_dependency 'bundler',                   '~> 1.7'
+  s.add_development_dependency 'bundler',                   '~> 2.1'
   s.add_development_dependency 'github-markup',             '~> 3.0'
   s.add_development_dependency 'pry',                       '~> 0.10'
   s.add_development_dependency 'rake',                      '~> 12.3'


### PR DESCRIPTION
Updated the script to go through Service Limits checks and look for
status not 'ok'

## Pull Request Checklist

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

> Hello,
> 
> This notification details recent changes in the AWS Trusted Advisor Checks.
> 
> If you get AWS Trusted Advisor check data for the combined "Service Limits" check with Check ID "eW7HH0l7J9" via API [1] or CLI [2] or console [3], this notification is to inform you of three changes.
> You may be doing this if you:
> 
> * Specifically call DescribeTrustedAdvisorCheckResult or DescribeTrustedAdvisorCheckSummaries for Check ID "eW7HH0l7J9"
> * Get a list of all checks in Trusted Advisor by calling DescribeTrustedAdvisorChecks and then get check result data or check summary data for each of the checks in the list by calling DescribeTrustedAdvisorCheckResult or DescribeTrustedAdvisorCheckSummaries.
> * Use the console (UI) to download the Excel sheet with all check results in it.
> What is changing?
> 
> There are three changes, outlined below:
> 
> * We have now enabled the newly launched vCPU-limits [4] with the EC2 On Demand Instances Service Limit check (ID: "0Xc6LMYG8P").
> * The combined "Service Limits" check with check ID "eW7HH0l7J9" no longer includes EC2 service limit information.
> * We plan to disable the combined "Service Limits" check with check ID "eW7HH0l7J9" on February 15, 2020. After this time you will not be able to access this check via API, CLI or console.
>
> How do I mitigate for this change?
> 
> * We recommend discontinuing the use of the Service Limits check (check ID "eW7HH0l7J9"). Instead, we recommend obtaining service limit data from the separate checks, per service, in the "service limit category" [5]. The checks in "service limit" category include all the information in the combined Service Limits check as well as 11 additional checks for improved coverage.
> * For EC2 service limits specifically, we recommend using the EC2 On Demand Instances Service Limit check (ID: "0Xc6LMYG8P") which now has support for vCPU limits.
> * If you use the console (UI) to download the Excel sheet with all check results in it, you will still be able to view service limits shown in individual tabs for each service. The EC2 service limits information is available in the tab named "EC2 On-Demand instances".

#### Known Compatibility Issues
