### PR TITLE
add Freeable memory metric to metrics-rds.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- metrics-rds.rb: added Freeable memory metric
 
 ## 18.6.0
 ### Added

--- a/bin/metrics-rds.rb
+++ b/bin/metrics-rds.rb
@@ -123,7 +123,8 @@ class RDSMetrics < Sensu::Plugin::Metric::CLI::Graphite
       'ReplicaLag' => 'Average',
       'SwapUsage' => 'Average',
       'BinLogDiskUsage' => 'Average',
-      'DiskQueueDepth' => 'Average'
+      'DiskQueueDepth' => 'Average',
+      'FreeableMemory' => 'Average'
     }
 
     @db_instance  = find_db_instance config[:db_instance_id]


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
no

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [x] Update README with any necessary configuration snippets

- [x] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### Purpose
RDS Freeable memory is quite useful metric when using RDS. Because you don't have any other memory related metric you can lean on.

#### Known Compatibility Issues
