### PR TITLE
Add a new check-target-group-instance-count check

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ The Sensu assets packaged from this repository are built against the Sensu Ruby 
 
 **check-subnet-ip-consumption**
 
+**check-target-group-instance-count**
+
 **check-vpc-nameservers**
 
 **check-instances-count.rb**

--- a/bin/check-target-group-instance-count.rb
+++ b/bin/check-target-group-instance-count.rb
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+#
+# check-target-group-instance-count
+#
+# DESCRIPTION:
+#   This plugin checks the count of instances of Application Load Balancer target groups
+#
+# OUTPUT:
+#   plain-text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: aws-sdk
+#   gem: sensu-plugin
+#
+# USAGE:
+#   Check the number of instances for a target group in a region
+#   check-target-group-instance-count.rb -r region -t target-group -w warn-count -c crit-count
+#
+# LICENSE:
+#   Copyright 2022 Etienne Duclos <etienne@tracktik.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+
+require 'aws-sdk'
+require 'sensu-plugin/check/cli'
+require 'sensu-plugins-aws'
+
+class CheckTargetGroupInstanceCount < Sensu::Plugin::Check::CLI
+  include Common
+
+  option :aws_region,
+         short: '-r AWS_REGION',
+         long: '--aws-region REGION',
+         description: 'AWS Region (defaults to us-east-1).',
+         default: 'us-east-1'
+
+  option :target_group,
+         short: '-t',
+         long: '--target-group TARGET_GROUP',
+         description: 'The ALB target group to check'
+
+  option :warn_count,
+         short: '-W WARN_COUNT',
+         long: '--warn WARN_COUNT',
+         description: 'Warn when the number of instances is equal or below this number',
+         default: 2,
+         proc: proc(&:to_i)
+
+  option :crit_count,
+         short: '-C CRIT_COUNT',
+         long: '--crit CRIT_COUNT',
+         description: 'Critical when the number of instances is equal or below this number',
+         default: 1,
+         proc: proc(&:to_i)
+
+  def alb
+    @alb ||= Aws::ElasticLoadBalancingV2::Client.new
+  end
+
+  def run
+    target_group = alb.describe_target_groups(names: [config[:target_group]]).target_groups[0]
+    health = alb.describe_target_health(target_group_arn: target_group.target_group_arn)
+    instances_count = health.target_health_descriptions.length
+
+    message = "Number of instances in target group: #{instances_count}"
+
+    if instances_count <= config[:crit_count]
+      critical message
+    elsif instances_count <= config[:warn_count]
+      warning message
+    else
+      ok message
+    end
+  end
+end

--- a/test/bin/check_target_group_instance_count_spec.rb
+++ b/test/bin/check_target_group_instance_count_spec.rb
@@ -1,0 +1,111 @@
+require 'aws-sdk'
+require_relative '../../bin/check-target-group-instance-count.rb'
+require_relative '../spec_helper.rb'
+
+class CheckTargetGroupInstanceCount
+  at_exit do
+    @@autorun = false
+  end
+
+  def critical(*)
+    'triggered critical'
+  end
+
+  def warning(*)
+    'triggered warning'
+  end
+
+  def ok(*)
+    'triggered ok'
+  end
+
+  def unknown(*)
+    'triggered unknown'
+  end
+end
+
+describe 'CheckTargetGroupInstanceCount' do
+  before :all do
+    @aws_stub = Aws::ElasticLoadBalancingV2::Client.new(stub_responses: true, region: 'us-east-1')
+    @aws_stub.stub_responses(:describe_target_groups, target_groups: [{ target_group_name: 'test', target_group_arn: 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/test/73e2d6bc24d8a067' }])
+  end
+
+  describe '#target_group' do
+    it 'should return a critical with an empty target group' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered critical')
+    end
+
+    it 'should return a critical when lower than default threshold' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      @aws_stub.stub_responses(:describe_target_health, target_health_descriptions: [{ health_check_port: '80' }])
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered critical')
+    end
+
+    it 'should return a warning when lower than default threshold' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      @aws_stub.stub_responses(:describe_target_health, target_health_descriptions: [{ health_check_port: '80' }, { health_check_port: '80' }])
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered warning')
+    end
+
+    it 'should return a ok when higher than default thresholds' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      @aws_stub.stub_responses(:describe_target_health, target_health_descriptions: [{ health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }])
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered ok')
+    end
+
+    it 'should return a critical when lower than set threshold' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      check.config[:crit_count] = 2
+      @aws_stub.stub_responses(:describe_target_health, target_health_descriptions: [{ health_check_port: '80' }, { health_check_port: '80' }])
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered critical')
+    end
+
+    it 'should return a warning when lower than set threshold' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      check.config[:warn_count] = 5
+      @aws_stub.stub_responses(:describe_target_health, target_health_descriptions: [{ health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }])
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered warning')
+    end
+
+    it 'should return a ok when higher than set thresholds' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      check.config[:warn_count] = 3
+      check.config[:warn_count] = 2
+      @aws_stub.stub_responses(:describe_target_health, target_health_descriptions: [{ health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }])
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered ok')
+    end
+
+    it 'should return a warning when lower than set warning threshold but higher than critical one' do
+      check = CheckTargetGroupInstanceCount.new
+      check.config[:target_group] = 'test'
+      check.config[:crit_count] = 2
+      check.config[:warn_count] = 5
+      @aws_stub.stub_responses(:describe_target_health, target_health_descriptions: [{ health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }, { health_check_port: '80' }])
+      allow(check).to receive(:alb).and_return(@aws_stub)
+
+      expect(check.run).to eq('triggered warning')
+    end
+  end
+end


### PR DESCRIPTION
#### General

- [ ] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [X] Existing tests pass

#### New Plugins

- [X] Tests

- [X] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose

Add a new check to get alerted if the number of instances on a specific Target Group drops below a certain level

#### Known Compatibility Issues
