### PR TITLE
Add --ok-no-file to check-s3-object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)
 
 ## [Unreleased]
+### Added
+- `check-s3-object.rb` - Added `--ok-no-file` option (@jaszka)
 
 ## 18.6.0
 ### Added

--- a/bin/check-s3-object.rb
+++ b/bin/check-s3-object.rb
@@ -108,6 +108,12 @@ class CheckS3Object < Sensu::Plugin::Check::CLI
          long: '--ok-on-multiple-objects',
          boolean: true
 
+  option :ok_no_file,
+         description: 'OK if file with given prefix is not found',
+         long: '--ok-no-file',
+         boolean: true,
+         default: false
+
   def aws_config
     { access_key_id: config[:aws_access_key],
       secret_access_key: config[:aws_secret_access_key],
@@ -167,7 +173,12 @@ class CheckS3Object < Sensu::Plugin::Check::CLI
         output = output.next_page while output.next_page?
 
         if output.contents.size.to_i < 1
-          critical "Object with prefix \"#{key_search}\" not found in bucket #{config[:bucket_name]}"
+          object_not_found = "Object with prefix \"#{key_search}\" not found in bucket #{config[:bucket_name]}"
+          if config[:ok_no_file]
+            ok object_not_found
+          else
+            critical object_not_found
+          end
         end
 
         if output.contents.size.to_i > 1


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [x] Update Changelog following the conventions laid out [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Add an option to pass check when file is not found. In our case we search group of files by some prefix and they are moved between "directories", so it's fine if they don't exist, the only problem is when they are too old.

#### Known Compatibility Issues
